### PR TITLE
[feat] Spring Security & JWT 설정 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,16 +30,29 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-    // aws 의존성 추가
+    // aws
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
 
-    // redis 의존성 추가
+    // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 
-    // flyway 의존성 추가
+    // flyway
     implementation "org.flywaydb:flyway-core"
+
     // flyway와 mysql 버전 8과 맞추기 위해 사용
-    implementation ("org.flywaydb:flyway-mysql")
+    implementation "org.flywaydb:flyway-mysql"
+
+    // h2
+    //runtimeOnly 'com.h2database:h2'
+
+    // spring security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/baggle/BaggleApplication.java
+++ b/src/main/java/org/baggle/BaggleApplication.java
@@ -9,6 +9,7 @@ public class BaggleApplication {
     static {
         System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
     }
+
     public static void main(String[] args) {
         SpringApplication.run(BaggleApplication.class, args);
     }

--- a/src/main/java/org/baggle/domain/sample/controller/SampleApiController.java
+++ b/src/main/java/org/baggle/domain/sample/controller/SampleApiController.java
@@ -2,14 +2,15 @@ package org.baggle.domain.sample.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.baggle.domain.sample.dto.request.SampleRequestDto;
-import org.baggle.domain.sample.dto.response.SampleResponseDto;
 import org.baggle.domain.sample.service.SampleService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
+import org.baggle.global.config.jwt.Token;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @RequiredArgsConstructor
 @Controller
@@ -17,8 +18,10 @@ public class SampleApiController {
     private final SampleService sampleService;
 
     @PostMapping("/sample")
-    public ResponseEntity<BaseResponse<?>> createSample(@RequestBody final SampleRequestDto sampleRequestDto) {
-        final SampleResponseDto sampleResponseDto = sampleService.createSample(sampleRequestDto);
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, sampleResponseDto));
+    public ResponseEntity<BaseResponse<?>> createSample(
+            @RequestHeader("Authorization") String token,
+            @RequestBody final SampleRequestDto sampleRequestDto) {
+        final Token tokenDto = sampleService.createSample(token, sampleRequestDto);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, tokenDto));
     }
 }

--- a/src/main/java/org/baggle/domain/sample/domain/Sample.java
+++ b/src/main/java/org/baggle/domain/sample/domain/Sample.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.sample.entity;
+package org.baggle.domain.sample.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/org/baggle/domain/sample/dto/request/SampleRequestDto.java
+++ b/src/main/java/org/baggle/domain/sample/dto/request/SampleRequestDto.java
@@ -1,21 +1,15 @@
 package org.baggle.domain.sample.dto.request;
 
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.baggle.domain.sample.entity.Sample;
+import org.baggle.domain.sample.domain.Sample;
 
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class SampleRequestDto {
     private String data;
-
-    @Builder
-    public SampleRequestDto(String data) {
-        this.data = data;
-    }
 
     public Sample toEntity() {
         return Sample.builder()

--- a/src/main/java/org/baggle/domain/sample/dto/response/SampleResponseDto.java
+++ b/src/main/java/org/baggle/domain/sample/dto/response/SampleResponseDto.java
@@ -2,7 +2,7 @@ package org.baggle.domain.sample.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.baggle.domain.sample.entity.Sample;
+import org.baggle.domain.sample.domain.Sample;
 
 
 @Getter

--- a/src/main/java/org/baggle/domain/sample/repository/SampleRepository.java
+++ b/src/main/java/org/baggle/domain/sample/repository/SampleRepository.java
@@ -1,7 +1,7 @@
 package org.baggle.domain.sample.repository;
 
 
-import org.baggle.domain.sample.entity.Sample;
+import org.baggle.domain.sample.domain.Sample;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/org/baggle/domain/sample/service/SampleService.java
+++ b/src/main/java/org/baggle/domain/sample/service/SampleService.java
@@ -1,28 +1,33 @@
 package org.baggle.domain.sample.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.baggle.domain.sample.domain.Sample;
 import org.baggle.domain.sample.dto.request.SampleRequestDto;
-import org.baggle.domain.sample.dto.response.SampleResponseDto;
-import org.baggle.domain.sample.entity.Sample;
 import org.baggle.domain.sample.exception.SampleDuplicateException;
 import org.baggle.domain.sample.repository.SampleRepository;
+import org.baggle.global.config.jwt.JwtProvider;
+import org.baggle.global.config.jwt.Token;
 import org.baggle.global.error.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class SampleService {
     private final SampleRepository sampleRepository;
+    private final JwtProvider jwtProvider;
 
-    public SampleResponseDto createSample(SampleRequestDto sampleRequestDto) {
+    public Token createSample(String token, SampleRequestDto sampleRequestDto) {
+        log.info("token: {}", token);
         Sample sample = sampleRequestDto.toEntity();
         validateDuplicateSample(sample.getData());
         Sample savedSample = sampleRepository.save(sample);
-        return SampleResponseDto.of(savedSample);
+        return jwtProvider.issueToken(savedSample.getId());
     }
 
     private void validateDuplicateSample(String data) {

--- a/src/main/java/org/baggle/global/common/BaseTimeEntity.java
+++ b/src/main/java/org/baggle/global/common/BaseTimeEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createDate;

--- a/src/main/java/org/baggle/global/config/JpaConfig.java
+++ b/src/main/java/org/baggle/global/config/JpaConfig.java
@@ -1,7 +1,9 @@
 package org.baggle.global.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@Configuration
 public class JpaConfig {
 }

--- a/src/main/java/org/baggle/global/config/auth/ExceptionHandlerFilter.java
+++ b/src/main/java/org/baggle/global/config/auth/ExceptionHandlerFilter.java
@@ -1,0 +1,53 @@
+package org.baggle.global.config.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.baggle.global.error.dto.ErrorBaseResponse;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (UnauthorizedException | InvalidValueException e) {
+            log.error("filter exception: ", e);
+            handleJwtException(response, e);
+        } catch (Exception ee) {
+            log.error("filter exception: ", ee);
+            handleException(response);
+        }
+    }
+
+    private void handleJwtException(HttpServletResponse response, Exception e) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        if (e instanceof UnauthorizedException ue) {
+            response.setStatus(ue.getErrorCode().getHttpStatus().value());
+            response.getWriter().write(objectMapper.writeValueAsString(ErrorBaseResponse.of(ue.getErrorCode())));
+        } else if (e instanceof InvalidValueException ie) {
+            response.setStatus(ie.getErrorCode().getHttpStatus().value());
+            response.getWriter().write(objectMapper.writeValueAsString(ErrorBaseResponse.of(ie.getErrorCode())));
+        }
+    }
+
+    private void handleException(HttpServletResponse response) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus().value());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorBaseResponse.of(ErrorCode.INTERNAL_SERVER_ERROR)));
+    }
+}

--- a/src/main/java/org/baggle/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/baggle/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package org.baggle.global.config.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.baggle.global.error.dto.ErrorBaseResponse;
+import org.baggle.global.error.exception.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        handleException(response);
+    }
+
+    private void handleException(HttpServletResponse response) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(ErrorCode.UNAUTHORIZED.getHttpStatus().value());
+        response.getWriter().write(objectMapper.writeValueAsString(ErrorBaseResponse.of(ErrorCode.UNAUTHORIZED)));
+    }
+}

--- a/src/main/java/org/baggle/global/config/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/org/baggle/global/config/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,39 @@
+package org.baggle.global.config.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.config.jwt.JwtProvider;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String accessToken = getAccessTokenFromHttpServletRequest(request);
+        jwtProvider.validateAccessToken(accessToken);
+        Long userId = jwtProvider.getSubject(accessToken);
+        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String getAccessTokenFromHttpServletRequest(HttpServletRequest request) {
+        String accessToken = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(accessToken) && accessToken.startsWith(BEARER)) {
+            return accessToken.substring(BEARER.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
@@ -1,0 +1,45 @@
+package org.baggle.global.config.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.config.jwt.JwtProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtProvider jwtProvider;
+    // TODO api 추가될 때 white list url 확인해서 추가하기.
+    private static final String[] whiteList = {"/sample", "/"};
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(whiteList);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagementConfigurer ->
+                        sessionManagementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptionHandlingConfigurer ->
+                        exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/global/config/auth/UserAuthentication.java
+++ b/src/main/java/org/baggle/global/config/auth/UserAuthentication.java
@@ -1,0 +1,12 @@
+package org.baggle.global.config.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}

--- a/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
+++ b/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
@@ -1,0 +1,80 @@
+package org.baggle.global.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Getter
+@Component
+public class JwtProvider {
+    @Value("${jwt.secret}")
+    private String secretKey;
+    @Value("${jwt.access-token-expire-time}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+    @Value("${jwt.refresh-token-expire-time}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+    private Key signatureKey;
+    private JwtParser jwtParser;
+
+    @PostConstruct
+    protected void init() {
+        byte[] secretKeyBytes = Decoders.BASE64.decode(secretKey);
+        this.signatureKey = Keys.hmacShaKeyFor(secretKeyBytes);
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(getSignatureKey()).build();
+    }
+
+    public Token issueToken(Long userId) {
+        return Token.of(createAccessToken(userId), createRefreshToken(userId));
+    }
+
+    private String createAccessToken(Long userId) {
+        final Date now = new Date();
+        final Date expiration = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(getSignatureKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String createRefreshToken(Long userId) {
+        final Date now = new Date();
+        final Date expiration = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
+        final String refreshToken = Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(getSignatureKey(), SignatureAlgorithm.HS256)
+                .compact();
+        // TODO refresh token -> redis 저장 로직 추가 예정입니다.
+        return refreshToken;
+    }
+
+    public void validateAccessToken(String accessToken) {
+        try {
+            jwtParser.parseClaimsJwt(accessToken);
+        } catch (JwtException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN);
+        } catch (IllegalArgumentException ee) {
+            throw new InvalidValueException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    public Long getSubject(String accessToken) {
+        return Long.valueOf(jwtParser.parseClaimsJwt(accessToken)
+                .getBody()
+                .getSubject());
+    }
+}

--- a/src/main/java/org/baggle/global/config/jwt/Token.java
+++ b/src/main/java/org/baggle/global/config/jwt/Token.java
@@ -1,0 +1,15 @@
+package org.baggle.global.config.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class Token {
+    private String accessToken;
+    private String refreshToken;
+
+    public static Token of(String accessToken, String refreshToken) {
+        return new Token(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -17,6 +17,10 @@ public enum ErrorCode {
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
+    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 엑세스 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
 
     /**
      * 403 Forbidden

--- a/src/main/java/org/baggle/infra/s3/S3Config.java
+++ b/src/main/java/org/baggle/infra/s3/S3Config.java
@@ -1,4 +1,4 @@
-package org.baggle.global.config;
+package org.baggle.infra.s3;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -19,13 +19,14 @@ public class S3Config {
     // S3 서버가 위한 지역을 가져옵니다.
     @Value("${cloud.aws.region.static}")
     private String region;
+
     /**
      * S3에 접근 권한이 주워진 객체를 Spring Bean에 등록합니다.
      * param: none
      * return: S3에 접근 권한이 주워진 객체를 return 합니다.
      */
     @Bean
-    public AmazonS3Client amazonS3Client(){
+    public AmazonS3Client amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(iamAccessKey, iamSecretKey);
         return (AmazonS3Client) AmazonS3ClientBuilder.standard()
                 .withRegion(region).enablePathStyleAccess()

--- a/src/main/java/org/baggle/infra/s3/S3Service.java
+++ b/src/main/java/org/baggle/infra/s3/S3Service.java
@@ -1,4 +1,4 @@
-package org.baggle.global.common;
+package org.baggle.infra.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -29,9 +29,9 @@ public class S3Service {
     private String defaultUrl;
 
     /**
-     *  S3에 이미지 파일을 업로드하는 메서드입니다.
-     *  param: 이미지 파일, user idx, 이미지 타입(ex. profile or post ...)
-     *  return: S3에 저장된 파일 이름 (db 저장 용도)
+     * S3에 이미지 파일을 업로드하는 메서드입니다.
+     * param: 이미지 파일, user idx, 이미지 타입(ex. profile or post ...)
+     * return: S3에 저장된 파일 이름 (db 저장 용도)
      */
     public String uploadFile(MultipartFile multipartFile, Long userId, String imageType) {
         if (multipartFile == null) return null;


### PR DESCRIPTION
## Related Issue 🍃
close #8 

## Description 🌴
- h2 database 의존성을 주석 처리하여 추가했습니다. 로컬에서 테스트시 주석 제거 후 사용하면 좋을 것 같습니다.
- spring security & jwt 의존성을 추가했습니다.
- s3 관련 코드를 global/common -> infra/s3 패키지로 이동했습니다.
- 추후 enum 클래스와 embedded 클래스도 하나의 domain이 될 수 있다고 생각되어 entity 패키지 명을 domain으로 변경했습니다.
- security config를 세팅했습니다.
- 인증 custom authentication, filter, entry point를 구현하였습니다.
- jwt 관련 provider, dto를 구현했습니다.
- sample 코드를 access token & refresh token issue 기능으로 변경하였습니다.
