### PR TITLE
[feat] @Entity 클래스 구현

### DIFF
--- a/src/main/java/org/baggle/domain/feed/domain/Feed.java
+++ b/src/main/java/org/baggle/domain/feed/domain/Feed.java
@@ -1,0 +1,23 @@
+package org.baggle.domain.feed.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.baggle.domain.meeting.domain.Participation;
+import org.baggle.global.common.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Feed extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feed_id")
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id")
+    private Participation participation;
+    @Column(nullable = false)
+    private String feedImageUrl;
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/ButtonAuthority.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/ButtonAuthority.java
@@ -1,0 +1,4 @@
+package org.baggle.domain.meeting.domain;
+
+public enum ButtonAuthority {
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/ButtonStatus.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/ButtonStatus.java
@@ -1,0 +1,4 @@
+package org.baggle.domain.meeting.domain;
+
+public enum ButtonStatus {
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -1,0 +1,36 @@
+package org.baggle.domain.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.baggle.global.common.BaseTimeEntity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Meeting extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_id")
+    private Long id;
+    @OneToMany(mappedBy = "meeting")
+    private List<Participation> participations = new ArrayList<>();
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private String place;
+    private LocalDate date;
+    private LocalTime time;
+    private String memo;
+    @Enumerated(value = EnumType.STRING)
+    private MeetingStatus meetingStatus;
+    @Enumerated(value = EnumType.STRING)
+    private ButtonStatus buttonStatus;
+    private String link;
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/MeetingAuthority.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/MeetingAuthority.java
@@ -1,0 +1,4 @@
+package org.baggle.domain.meeting.domain;
+
+public enum MeetingAuthority {
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/MeetingStatus.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/MeetingStatus.java
@@ -1,0 +1,4 @@
+package org.baggle.domain.meeting.domain;
+
+public enum MeetingStatus {
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -22,8 +22,10 @@ public class Participation extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id")
     private Meeting meeting;
-    @OneToOne(mappedBy = "participation")
+    @OneToOne(mappedBy = "participation", fetch = FetchType.LAZY)
     private Feed feed;
+    @OneToOne(mappedBy = "participation", fetch = FetchType.LAZY)
+    private Report report;
     @Enumerated(value = EnumType.STRING)
     private MeetingAuthority meetingAuthority;
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -1,0 +1,33 @@
+package org.baggle.domain.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.baggle.domain.feed.domain.Feed;
+import org.baggle.domain.user.domain.User;
+import org.baggle.global.common.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Participation extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participation_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+    @OneToOne(mappedBy = "participation")
+    private Feed feed;
+    @Enumerated(value = EnumType.STRING)
+    private MeetingAuthority meetingAuthority;
+    @Enumerated(value = EnumType.STRING)
+    private ParticipationMeetingStatus participationMeetingStatus;
+    @Enumerated(value = EnumType.STRING)
+    private ButtonAuthority buttonAuthority;
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/ParticipationMeetingStatus.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/ParticipationMeetingStatus.java
@@ -1,0 +1,4 @@
+package org.baggle.domain.meeting.domain;
+
+public enum ParticipationMeetingStatus {
+}

--- a/src/main/java/org/baggle/domain/meeting/domain/Report.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Report.java
@@ -1,0 +1,21 @@
+package org.baggle.domain.meeting.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.baggle.domain.feed.domain.Feed;
+import org.baggle.global.common.BaseTimeEntity;
+
+@Getter
+@Entity
+public class Report extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id")
+    private Participation participation;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+}

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -1,0 +1,21 @@
+package org.baggle.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.baggle.global.common.BaseTimeEntity;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "Users")
+@Entity
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    private String profileImageUrl;
+    @Column(nullable = false)
+    private String nickname;
+}

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -8,7 +8,7 @@ import org.baggle.global.common.BaseTimeEntity;
 @AllArgsConstructor
 @Builder
 @Getter
-@Table(name = "Users")
+@Table(name = "users")
 @Entity
 public class User extends BaseTimeEntity {
     @Id

--- a/src/main/java/org/baggle/global/common/BaseTimeEntity.java
+++ b/src/main/java/org/baggle/global/common/BaseTimeEntity.java
@@ -18,5 +18,5 @@ public abstract class BaseTimeEntity {
     @Column(updatable = false)
     private LocalDateTime createDate;
     @LastModifiedDate
-    private LocalDateTime lashModifiedDate;
+    private LocalDateTime lastModifiedDate;
 }


### PR DESCRIPTION
## Related Issue 🍃
close #11

## Description 🌴
- User Entity 클래스를 구현하였습니다. (Database 'user' 예약어로 인해 Entity는 User, Table은 users로 지정했습니다.)
- Meeting Entity 클래스를 구현하였습니다.
- Participation Entity 클래스를 구현하였습니다.
- Feed Entity 클래스를 구현하였습니다.
- Report Entity 클래스를 구현하였습니다.
- Enum Field에 해당하는 Authority와 Status Enum 클래스를 구현하였습니다. 추후 개발 시 필요한 권한, 상태를 추가하면 좋을 것 같습니다.
- @Setter는 의도가 불명확하고 변경하면 안 되는 값을 변경할 여지가 있기 때문에 안정성을 보장할 수 없어서 열어두지 않았습니다. 수정자가 필요한 경우 변경 의도를 확인할 수 있는 의미 있는 이름의 메서드를 추가하여 사용하면 좋을 것 같습니다.
- 매개 변수가 많아져도 높은 가독성 유지가 가능하고 필요한 데이터만 추가할 수 있도록 @Builder를 적용하였습니다.
- JPA 기본 스펙 상 기본 생성자를 요구하기 때문에 @NoArgsConstructor를 적용하였습니다. 그리고 여러 위치에서 무분별한 엔티티 객체 생성을 방지하고 지연 로딩의 경우 연관된 엔티티 객체가 프록시 객체로 존재하는데 이때 프록시 객체가 해당 엔티티를 상속받을 수 있도록 접근제어자를 private이 아닌 protected로 지정하였습니다.
- 아래 첨부된 ddl은 h2 database로 테스트한 결과입니다.

```
create table users (
    create_date timestamp(6),
    last_modified_date timestamp(6),
    user_id bigint generated by default as identity,
    nickname varchar(255) not null,
    profile_image_url varchar(255),
    primary key (user_id)
)
    
create table meeting (
    date date,
    time time(6),
    create_date timestamp(6),
    last_modified_date timestamp(6),
    meeting_id bigint generated by default as identity,
    button_status varchar(255) check (button_status in ()),
    link varchar(255),
    meeting_status varchar(255) check (meeting_status in ()),
    memo varchar(255),
    place varchar(255) not null,
    title varchar(255) not null,
    primary key (meeting_id)
)
    
create table participation (
    create_date timestamp(6),
    last_modified_date timestamp(6),
    meeting_id bigint,
    participation_id bigint generated by default as identity,
    user_id bigint,
    button_authority varchar(255) check (button_authority in ()),
    meeting_authority varchar(255) check (meeting_authority in ()),
    participation_meeting_status varchar(255) check (participation_meeting_status in ()),
    primary key (participation_id)
)

create table feed (
    create_date timestamp(6),
    feed_id bigint generated by default as identity,
    last_modified_date timestamp(6),
    participation_id bigint unique,
    feed_image_url varchar(255) not null,
    primary key (feed_id)
)

create table report (
    create_date timestamp(6),
    feed_id bigint,
    last_modified_date timestamp(6),
    participation_id bigint unique,
    report_id bigint generated by default as identity,
    primary key (report_id)
)
```