### PR TITLE
[feat] JWT & Redis 세팅

### DIFF
--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -1,0 +1,35 @@
+package org.baggle.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@Controller
+public class AuthApiController {
+    private final AuthService authService;
+
+    @PostMapping("/signin")
+    public ResponseEntity<BaseResponse<?>> signIn(@RequestHeader("Authorization") final String token) {
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, authService.signin(token)));
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader("Authorization") final String token,
+                                                  @RequestParam("image") final MultipartFile image,
+                                                  @RequestParam final String nickname,
+                                                  @RequestParam final String platform) {
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, authService.signup(token, image, nickname, platform)));
+    }
+
+    @GetMapping("/reissue")
+    public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader("Authorization") final String refreshToken) {
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, authService.reissue(refreshToken)));
+    }
+}

--- a/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
+++ b/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
@@ -1,0 +1,17 @@
+package org.baggle.domain.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 60)
+public class RefreshToken {
+    @Id
+    private Long id;
+    private String refreshToken;
+}

--- a/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
@@ -1,0 +1,5 @@
+package org.baggle.domain.user.dto.request;
+
+// TODO
+public class UserSignInRequestDto {
+}

--- a/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
@@ -1,0 +1,5 @@
+package org.baggle.domain.user.dto.response;
+
+// TODO
+public class UserAuthResponseDto {
+}

--- a/src/main/java/org/baggle/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/baggle/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package org.baggle.domain.user.repository;
+
+import org.baggle.domain.user.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/org/baggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/baggle/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package org.baggle.domain.user.repository;
+
+import org.baggle.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -1,0 +1,31 @@
+package org.baggle.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.domain.user.dto.response.UserAuthResponseDto;
+import org.baggle.domain.user.repository.UserRepository;
+import org.baggle.global.config.jwt.Token;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class AuthService {
+    private final UserRepository userRepository;
+
+    // TODO
+    public UserAuthResponseDto signin(String token) {
+        return new UserAuthResponseDto();
+    }
+
+    // TODO
+    public UserAuthResponseDto signup(String token, MultipartFile image, String nickname, String platform) {
+        return new UserAuthResponseDto();
+    }
+
+    // TODO
+    public Token reissue(String refreshToken) {
+        return null;
+    }
+}


### PR DESCRIPTION
## Related Issue 🍃
close #10 

## Description 🌴
- refresh token & refresh token repository를 구현하였습니다.
- 기존에 구현되었던 JwtProvider 로직을 리팩터링하였고 refresh token 검증 메서드를 추가 구현하였습니다.
- 소셜 로그인, 회원 가입, jwt 재발급 API 스펙을 간단하게 정의하였습니다. 추후 다른 이슈로 기능 구현 예정입니다.
