### PR TITLE
[feat] 애플 소셜 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
     // fcm
     implementation 'com.google.firebase:firebase-admin:9.1.1'
+
+    // open feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/baggle/domain/user/auth/apple/AppleFeignClient.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/AppleFeignClient.java
@@ -1,0 +1,10 @@
+package org.baggle.domain.user.auth.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "apple-feign-client", url = "https://appleid.apple.com/auth")
+public interface AppleFeignClient {
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/AppleOAuthProvider.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/AppleOAuthProvider.java
@@ -1,0 +1,34 @@
+package org.baggle.domain.user.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AppleOAuthProvider {
+    private final AppleFeignClient appleFeignClient;
+    private final IdentityTokenParser identityTokenParser;
+    private final PublicKeyGenerator publicKeyGenerator;
+    private final IdentityTokenValidator identityTokenValidator;
+
+    public String getApplePlatformId(String identityToken) {
+        Map<String, String> headers = identityTokenParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
+        PublicKey publicKey = publicKeyGenerator.generatePublicKeyWithApplePublicKeys(headers, applePublicKeys);
+        Claims claims = identityTokenParser.parseWithPublicKeyAndGetClaims(identityToken, publicKey);
+        validateClaims(claims);
+        return claims.getSubject();
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!identityTokenValidator.isValidIdentityToken(claims)) {
+            throw new UnauthorizedException(ErrorCode.INVALID_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/ApplePublicKey.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/ApplePublicKey.java
@@ -1,0 +1,16 @@
+package org.baggle.domain.user.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ApplePublicKey {
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/ApplePublicKeys.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/ApplePublicKeys.java
@@ -1,0 +1,22 @@
+package org.baggle.domain.user.auth.apple;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.UnauthorizedException;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ApplePublicKeys {
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchesApplePublicKey(String alg, String kid) {
+        return keys.stream()
+                .filter(applePublicKey -> applePublicKey.getAlg().equals(alg) && applePublicKey.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_IDENTITY_TOKEN));
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenParser.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenParser.java
@@ -1,0 +1,50 @@
+package org.baggle.domain.user.auth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class IdentityTokenParser {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encoded = identityToken.split("\\.")[0];
+            String decoded = new String(Base64.getUrlDecoder().decode(encoded));
+            return objectMapper.readValue(decoded, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parseWithPublicKeyAndGetClaims(String identityToken, PublicKey publicKey) {
+        try {
+            return getJwtParser(publicKey)
+                    .parseClaimsJwt(identityToken)
+                    .getBody();
+        } catch (JwtException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_IDENTITY_TOKEN);
+        } catch (IllegalArgumentException ee) {
+            throw new InvalidValueException(ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    private JwtParser getJwtParser(Key key) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenValidator.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenValidator.java
@@ -1,0 +1,18 @@
+package org.baggle.domain.user.auth.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdentityTokenValidator {
+    @Value("${oauth.apple.iss}")
+    private String iss;
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    public boolean isValidIdentityToken(Claims claims) {
+        return claims.getIssuer().contains(iss)
+                && claims.getAudience().equals(clientId);
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/PublicKeyGenerator.java
@@ -1,0 +1,32 @@
+package org.baggle.domain.user.auth.apple;
+
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class PublicKeyGenerator {
+    public PublicKey generatePublicKeyWithApplePublicKeys(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey = applePublicKeys
+                .getMatchesApplePublicKey(headers.get("alg"), headers.get("kid"));
+        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.getN());
+        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.getE());
+        RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(
+                new BigInteger(1, nBytes), new BigInteger(1, eBytes));
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new UnauthorizedException(ErrorCode.APPLE_PUBLIC_KEY_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
@@ -1,5 +1,13 @@
 package org.baggle.domain.user.dto.request;
 
-// TODO
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class UserSignInRequestDto {
+    private String platform;
+    private String fcmToken;
 }

--- a/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
@@ -1,5 +1,26 @@
 package org.baggle.domain.user.dto.response;
 
-// TODO
+import lombok.Builder;
+import lombok.Getter;
+import org.baggle.domain.user.domain.User;
+import org.baggle.global.config.jwt.Token;
+
+@Builder
+@Getter
 public class UserAuthResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String platform;
+    private String profileImageUrl;
+    private String nickname;
+
+    public static UserAuthResponseDto of(Token token, User user) {
+        return UserAuthResponseDto.builder()
+                .accessToken(token.getAccessToken())
+                .refreshToken(token.getAccessToken())
+                //.platform(user.getPlatform())
+                .profileImageUrl(user.getProfileImageUrl())
+                .nickname(user.getNickname())
+                .build();
+    }
 }

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -16,12 +16,12 @@ public class AuthService {
 
     // TODO
     public UserAuthResponseDto signin(String token) {
-        return new UserAuthResponseDto();
+        return null;
     }
 
     // TODO
     public UserAuthResponseDto signup(String token, MultipartFile image, String nickname, String platform) {
-        return new UserAuthResponseDto();
+        return null;
     }
 
     // TODO

--- a/src/main/java/org/baggle/global/config/FeignClientConfig.java
+++ b/src/main/java/org/baggle/global/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.baggle.global.config;
+
+import org.baggle.BaggleApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackageClasses = BaggleApplication.class)
+@Configuration
+public class FeignClientConfig {
+}

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
+    INVALID_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 아이덴터티 토큰입니다."),
+    APPLE_PUBLIC_KEY_EXCEPTION(HttpStatus.UNAUTHORIZED, "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
+
 
     /**
      * 403 Forbidden
@@ -34,7 +37,7 @@ public enum ErrorCode {
     FCM_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "FCM 토큰을 찾을 수 없습니다."),
 
     /**
-     * 405 METHOD NOT ALLOWED
+     * 405 Method Not Allowed
      */
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
 


### PR DESCRIPTION
## Related Issue 🍃
close #17 

## Description 🌴
- 클라이언트로부터 애플 identity token을 받아 애플 플랫폼 고유 id를 가져올 수 있는 oauth provider를 구현하였습니다.
- 애플 공개키를 가져오기 위해 https 통신이 필요하여 open feign 라이브러리를 사용하였습니다.