### PR TITLE
[feat] 애플 회원 가입 API 구현

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
@@ -25,4 +25,9 @@ public class FcmToken extends BaseTimeEntity {
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    public void changeUser(User user) {
+        this.user = user;
+        user.changeFcmToken(this);
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -3,6 +3,7 @@ package org.baggle.domain.meeting.repository;
 import org.baggle.domain.meeting.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -11,5 +12,5 @@ import java.util.List;
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("SELECT m FROM Meeting m WHERE " +
             "m.date = :currentDate AND m.time between :prevTime and :currentTime ")
-    List<Meeting> findMeetingsStartingSoon(LocalTime prevTime, LocalDate currentDate, LocalTime currentTime);
+    List<Meeting> findMeetingsStartingSoon(@Param(value = "prevTime") LocalTime prevTime, @Param(value = "currentDate") LocalDate currentDate, @Param(value = "currentTime") LocalTime currentTime);
 }

--- a/src/main/java/org/baggle/domain/user/auth/apple/PublicKeyGenerator.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/PublicKeyGenerator.java
@@ -26,7 +26,7 @@ public class PublicKeyGenerator {
             KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
             return keyFactory.generatePublic(rsaPublicKeySpec);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw new UnauthorizedException(ErrorCode.APPLE_PUBLIC_KEY_EXCEPTION);
+            throw new UnauthorizedException(ErrorCode.UNABLE_TO_CREATE_APPLE_PUBLIC_KEY);
         }
     }
 }

--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -1,9 +1,12 @@
 package org.baggle.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.user.dto.request.UserSignInRequestDto;
+import org.baggle.domain.user.dto.response.UserAuthResponseDto;
 import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
+import org.baggle.global.config.jwt.Token;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -16,20 +19,25 @@ public class AuthApiController {
     private final AuthService authService;
 
     @PostMapping("/signin")
-    public ResponseEntity<BaseResponse<?>> signIn(@RequestHeader("Authorization") final String token) {
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, authService.signin(token)));
+    public ResponseEntity<BaseResponse<?>> signIn(@RequestHeader("Authorization") final String token,
+                                                  @RequestBody final UserSignInRequestDto userSignInRequestDto) {
+        final UserAuthResponseDto userAuthResponseDto = authService.signin(token, userSignInRequestDto);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, userAuthResponseDto));
     }
 
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader("Authorization") final String token,
-                                                  @RequestParam("image") final MultipartFile image,
+                                                  @RequestParam("file") final MultipartFile image,
                                                   @RequestParam final String nickname,
-                                                  @RequestParam final String platform) {
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, authService.signup(token, image, nickname, platform)));
+                                                  @RequestParam final String platform,
+                                                  @RequestParam final String fcmToken) {
+        final UserAuthResponseDto userAuthResponseDto = authService.signup(token, image, nickname, platform, fcmToken);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, userAuthResponseDto));
     }
 
     @GetMapping("/reissue")
     public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader("Authorization") final String refreshToken) {
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, authService.reissue(refreshToken)));
+        final Token reissuedToken = authService.reissue(refreshToken);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, reissuedToken));
     }
 }

--- a/src/main/java/org/baggle/domain/user/domain/Platform.java
+++ b/src/main/java/org/baggle/domain/user/domain/Platform.java
@@ -1,7 +1,25 @@
 package org.baggle.domain.user.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
 public enum Platform {
-    KAKAO,
-    APPLE,
-    WITHDRAW
+    KAKAO("kakao"),
+    APPLE("apple"),
+    WITHDRAW("withdraw");
+
+    private final String stringPlatform;
+
+    public static Platform getEnumPlatformFromStringPlatform(String stringPlatform) {
+        return Arrays.stream(values())
+                .filter(platform -> platform.stringPlatform.equals(stringPlatform))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(ErrorCode.INVALID_PLATFORM_TYPE));
+    }
 }

--- a/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
+++ b/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
@@ -14,4 +14,11 @@ public class RefreshToken {
     @Id
     private Long id;
     private String refreshToken;
+
+    public static RefreshToken createRefreshToken(Long userId, String refreshToken) {
+        return RefreshToken.builder()
+                .id(userId)
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -30,4 +30,26 @@ public class User extends BaseTimeEntity {
     private String refreshToken;
     @Enumerated(value = EnumType.STRING)
     private Platform platform;
+
+    public static User createUserWithFcmToken(String profileImageUrl, String nickname, String fcmToken, String platformId, Platform platform) {
+        User user = User.builder()
+                .profileImageUrl(profileImageUrl)
+                .nickname(nickname)
+                .platformId(platformId)
+                .platform(platform)
+                .build();
+        FcmToken token = FcmToken.builder()
+                .fcmToken(fcmToken)
+                .build();
+        token.changeUser(user);
+        return user;
+    }
+
+    public void changeFcmToken(FcmToken fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
@@ -18,7 +18,7 @@ public class UserAuthResponseDto {
         return UserAuthResponseDto.builder()
                 .accessToken(token.getAccessToken())
                 .refreshToken(token.getAccessToken())
-                //.platform(user.getPlatform())
+                .platform(user.getPlatform().getStringPlatform())
                 .profileImageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())
                 .build();

--- a/src/main/java/org/baggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/baggle/domain/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package org.baggle.domain.user.repository;
 
+import org.baggle.domain.user.domain.Platform;
 import org.baggle.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    List<User> findUsersByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -1,31 +1,83 @@
 package org.baggle.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.user.auth.apple.AppleOAuthProvider;
+import org.baggle.domain.user.domain.Platform;
+import org.baggle.domain.user.domain.RefreshToken;
+import org.baggle.domain.user.domain.User;
+import org.baggle.domain.user.dto.request.UserSignInRequestDto;
 import org.baggle.domain.user.dto.response.UserAuthResponseDto;
+import org.baggle.domain.user.repository.RefreshTokenRepository;
 import org.baggle.domain.user.repository.UserRepository;
+import org.baggle.global.common.ImageType;
+import org.baggle.global.config.jwt.JwtProvider;
 import org.baggle.global.config.jwt.Token;
+import org.baggle.global.error.exception.ConflictException;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.infra.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class AuthService {
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final S3Service s3Service;
+    private final JwtProvider jwtProvider;
+    private final AppleOAuthProvider appleOAuthProvider;
 
     // TODO
-    public UserAuthResponseDto signin(String token) {
+    public UserAuthResponseDto signin(String token, UserSignInRequestDto userSignInRequestDto) {
         return null;
     }
 
-    // TODO
-    public UserAuthResponseDto signup(String token, MultipartFile image, String nickname, String platform) {
-        return null;
+    public UserAuthResponseDto signup(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
+        Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
+        String platformId = getPlatformIdFromToken(token, enumPlatform);
+        validateDuplicateUser(enumPlatform, platformId);
+        String profileImageUrl = uploadProfileImageToS3AndGetProfileImageUrl(image, ImageType.PROFILE);
+        User user = User.createUserWithFcmToken(profileImageUrl, nickname, fcmToken, platformId, enumPlatform);
+        User savedUser = userRepository.save(user);
+        Token issuedToken = jwtProvider.issueToken(savedUser.getId());
+        updateRefreshToken(savedUser, issuedToken.getRefreshToken());
+        return UserAuthResponseDto.of(issuedToken, savedUser);
     }
 
     // TODO
     public Token reissue(String refreshToken) {
         return null;
+    }
+
+    private Platform getEnumPlatformFromStringPlatform(String platform) {
+        return Platform.getEnumPlatformFromStringPlatform(platform);
+    }
+
+    private String getPlatformIdFromToken(String token, Platform platform) {
+        if (platform == Platform.KAKAO) {
+            // TODO
+            return null;
+        }
+        return appleOAuthProvider.getApplePlatformId(token);
+    }
+
+    private void validateDuplicateUser(Platform platform, String platformId) {
+        List<User> findUsers = userRepository.findUsersByPlatformAndPlatformId(platform, platformId);
+        if (!findUsers.isEmpty()) {
+            throw new ConflictException(ErrorCode.DUPLICATE_USER);
+        }
+    }
+
+    private void updateRefreshToken(User user, String refreshToken) {
+        user.updateRefreshToken(refreshToken);
+        refreshTokenRepository.save(RefreshToken.createRefreshToken(user.getId(), refreshToken));
+    }
+
+    private String uploadProfileImageToS3AndGetProfileImageUrl(MultipartFile image, ImageType imageType) {
+        return s3Service.uploadFile(image, imageType.getImageType());
     }
 }

--- a/src/main/java/org/baggle/global/common/ImageType.java
+++ b/src/main/java/org/baggle/global/common/ImageType.java
@@ -1,0 +1,13 @@
+package org.baggle.global.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ImageType {
+    PROFILE("profile"),
+    FEED("feed");
+
+    private final String imageType;
+}

--- a/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtProvider jwtProvider;
     // TODO api 추가될 때 white list url 확인해서 추가하기.
-    private static final String[] whiteList = {"/sample", "/"};
+    private static final String[] whiteList = {"/api/user/signin", "/api/user/signup", "/api/user/reissue"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -12,6 +12,9 @@ public enum ErrorCode {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_MULTIPART_FILE(HttpStatus.BAD_REQUEST, "유효하지 않은 파일입니다."),
+    INVALID_FILE_UPLOAD(HttpStatus.BAD_REQUEST, "s3 파일 업로드에 실패했습니다."),
+    INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 플랫폼 타입입니다."),
 
     /**
      * 401 Unauthorized
@@ -22,8 +25,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
     INVALID_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 아이덴터티 토큰입니다."),
-    APPLE_PUBLIC_KEY_EXCEPTION(HttpStatus.UNAUTHORIZED, "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
-
+    UNABLE_TO_CREATE_APPLE_PUBLIC_KEY(HttpStatus.UNAUTHORIZED, "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
 
     /**
      * 403 Forbidden
@@ -46,6 +48,7 @@ public enum ErrorCode {
      * 409 Conflict
      */
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+    DUPLICATE_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/org/baggle/infra/s3/S3Service.java
+++ b/src/main/java/org/baggle/infra/s3/S3Service.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,8 +16,8 @@ import java.io.InputStream;
 import java.util.UUID;
 
 @Slf4j
-@Service
 @RequiredArgsConstructor
+@Service
 public class S3Service {
     // S3Config에 등록된 S3 접근 권한 객체입니다.
     private final AmazonS3Client amazonS3Client;
@@ -24,7 +26,7 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    // yml에 등록함 base url입니다.
+    // yml에 등록된 base url입니다.
     @Value("${cloud.aws.s3.uploadPath}")
     private String defaultUrl;
 
@@ -33,20 +35,23 @@ public class S3Service {
      * param: 이미지 파일, user idx, 이미지 타입(ex. profile or post ...)
      * return: S3에 저장된 파일 이름 (db 저장 용도)
      */
-    public String uploadFile(MultipartFile multipartFile, Long userId, String imageType) {
-        if (multipartFile == null) return null;
-        if (multipartFile.isEmpty()) return null;
-        String savedFileName = getSavedFileName(multipartFile, userId, imageType);
+    public String uploadFile(MultipartFile multipartFile, String imageType) {
+        validateMultipartFile(multipartFile);
+        String savedFileName = getSavedFileName(multipartFile, imageType);
         ObjectMetadata metadata = new ObjectMetadata();
-
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3Client.putObject(bucketName, savedFileName, inputStream, metadata);
         } catch (IOException e) {
             log.error("Failed to upload image", e);
-            // 추후 변경
-            // ex) throw new BusinessException(ErrorMessage.INVALID_FILE_UPLOAD);
+            throw new InvalidValueException(ErrorCode.INVALID_FILE_UPLOAD);
         }
         return getResourceUrl(savedFileName);
+    }
+
+    private void validateMultipartFile(MultipartFile multipartFile) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new InvalidValueException(ErrorCode.INVALID_MULTIPART_FILE);
+        }
     }
 
     /**
@@ -64,9 +69,9 @@ public class S3Service {
      * param: MultipartFile, user idx, 이미지 타입
      * return: 생성된 파일 이름 <--> user{번호}/{이미지 타입}/{UUID}-{입력된 파일 이름}
      */
-    private String getSavedFileName(MultipartFile multipartFile, Long userId, String imageType) {
-        return String.format("user%s/%s/%s-%s",
-                userId, imageType, getRandomUUID(), multipartFile.getOriginalFilename());
+    private String getSavedFileName(MultipartFile multipartFile, String imageType) {
+        return String.format("%s/%s-%s",
+                imageType, getRandomUUID(), multipartFile.getOriginalFilename());
     }
 
     /**
@@ -79,7 +84,7 @@ public class S3Service {
     }
 
     /**
-     * S3에 저장된 파일에 접근할 수 있는 url을 만듭니다.
+     * S3에 저장된 파일에 접근할 수 있는 URL을 만듭니다.
      * param: 저장된 파일 이름 (db에서 확인 가능)
      * return: 파일 접근 url
      */


### PR DESCRIPTION
## Related Issue 🍃
close #21 

## Description 🌴
- S3 upload 메서드에 userId 파라미터를 제거하였습니다.
- S3 service에 MultipartFile validate 기능 추가 및 로직을 분리하였습니다.
- 인증 관련 API 스펙에서 누락되었던 부분을 수정하였습니다.
- Spring Security white list에 로그인, 회원 가입, jwt 재발급 url을 추가하였습니다.
- 공통 회원 가입 로직을 구현하였고 애플 플랫폼 OAuth를 우선적으로 구현하였습니다.
- 회원 가입 관련 error code를 추가하였습니다.
- MeetingRepository에 @Param 누락으로 오류가 발생하여 해당 애노테이션을 추가하였습니다.
