### PR TITLE
[refactor] 인증 사진 업로드 & 긴급소집 알람 api 예외 처리 개선

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
@@ -59,10 +59,6 @@ public class FcmNotificationService {
         return fcmNotificationRepository.existsById(key);
     }
 
-    public List<FcmToken> findFcmTokens(Long meetingId) {
-        return fcmRepository.findByUserParticipationsMeetingId(meetingId);
-    }
-
     @Transactional
     public List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
         return participationRepository.findFcmTokensByMeetingAndButtonAuthority(meeting, buttonAuthority);

--- a/src/main/java/org/baggle/domain/fcm/service/FcmService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmService.java
@@ -13,6 +13,8 @@ import org.baggle.global.error.exception.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.baggle.global.error.exception.ErrorCode.FCM_TOKEN_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -40,5 +42,9 @@ public class FcmService {
         fcmToken.updateFcmToken(requestDto.getUpdateFCMToken());
 
         return UpdateFcmTokenResponseDto.of(fcmToken);
+    }
+
+    public List<FcmToken> findFcmTokens(Long meetingId) {
+        return fcmRepository.findByUserParticipationsMeetingId(meetingId);
     }
 }

--- a/src/main/java/org/baggle/domain/feed/dto/request/FeedUploadRequestDto.java
+++ b/src/main/java/org/baggle/domain/feed/dto/request/FeedUploadRequestDto.java
@@ -4,8 +4,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class FeedUploadRequestDto {
     private Long participationId;
+    private LocalDateTime time;
 }

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -46,7 +46,7 @@ public class FeedService {
      * throw 모임이 확정되지 않은 경우
      * throw 긴급소집 이벤트가 진행 중이 아닌 경우
      */
-    public FeedUploadResponseDto feedUpload(FeedUploadRequestDto requestDto, MultipartFile feedImage) throws InvalidValueException {
+    public FeedUploadResponseDto feedUpload(FeedUploadRequestDto requestDto, MultipartFile feedImage) {
         Participation participation = participationRepository.findById(requestDto.getParticipationId()).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
         if (!meetingService.isValidTime(participation.getMeeting()))
             throw new InvalidValueException(INVALID_MEETING_TIME);

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -4,16 +4,20 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
 import org.baggle.domain.fcm.repository.FcmRepository;
+import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationService;
 import org.baggle.domain.feed.domain.Feed;
 import org.baggle.domain.feed.dto.request.FeedUploadRequestDto;
 import org.baggle.domain.feed.dto.response.FeedNotificationResponseDto;
 import org.baggle.domain.feed.dto.response.FeedUploadResponseDto;
 import org.baggle.domain.feed.repository.FeedRepository;
+import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
+import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.global.common.ImageType;
 import org.baggle.global.error.exception.EntityNotFoundException;
+import org.baggle.global.error.exception.InvalidValueException;
 import org.baggle.infra.s3.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.baggle.global.error.exception.ErrorCode.PARTICIPATION_NOT_FOUND;
+import static org.baggle.global.error.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -32,18 +36,37 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final S3Service s3Service;
     private final FcmNotificationService fcmNotificationService;
+    private final FcmTimerRepository fcmTimerRepository;
     private final FcmRepository fcmRepository;
+    private final MeetingService meetingService;
 
-    public FeedUploadResponseDto feedUpload(FeedUploadRequestDto requestDto, MultipartFile feedImage) {
+    /**
+     * 피드를 업로드하는 메서드입니다.
+     * throw 모임에 참가자가 없는 경우
+     * throw 모임이 확정되지 않은 경우
+     * throw 긴급소집 이벤트가 진행 중이 아닌 경우
+     */
+    public FeedUploadResponseDto feedUpload(FeedUploadRequestDto requestDto, MultipartFile feedImage) throws InvalidValueException {
         Participation participation = participationRepository.findById(requestDto.getParticipationId()).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
+        if (!meetingService.isValidTime(participation.getMeeting()))
+            throw new InvalidValueException(INVALID_MEETING_TIME);
+        if (!validateCertificationTime(participation.getMeeting()))
+            throw new InvalidValueException(INVALID_CERTIFICATION_TIME);
         String imgUrl = s3Service.uploadFile(feedImage, ImageType.FEED.getImageType());
         Feed feed = Feed.createParticipationWithFeedImg(participation, imgUrl);
         feedRepository.save(feed);
         return FeedUploadResponseDto.of(feed.getId());
     }
 
-    public FeedNotificationResponseDto uploadNotification(Long requestId){
+    /**
+     * 긴급소집 알람을 전송하는 api입니다.
+     * throw 모임에 참가자가 없는 경우
+     * throw 모임이 확정되지 않은 경우
+     */
+    public FeedNotificationResponseDto uploadNotification(Long requestId) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
+        if (!meetingService.isValidTime(participation.getMeeting()))
+            throw new InvalidValueException(INVALID_MEETING_TIME);
         // 알람을 broadcast 하는 code 입니다.
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(participation.getMeeting().getId());
         FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
@@ -52,5 +75,13 @@ public class FeedService {
         LocalDateTime startTime = LocalDateTime.now();
         fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), startTime);
         return FeedNotificationResponseDto.of(participation.getMeeting(), startTime);
+    }
+
+    /**
+     * 긴급 소집 이벤트 활성화 여부를 확인하는 코드
+     * return: 긴급 소집 이벤트 활성화시 True else False
+     */
+    private Boolean validateCertificationTime(Meeting meeting) {
+        return fcmTimerRepository.existsById(meeting.getId());
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -24,18 +24,17 @@ import static org.baggle.global.error.exception.ErrorCode.MEETING_NOT_FOUND;
 @Service
 public class MeetingService {
     private final MeetingRepository meetingRepository;
-    private final FeedRepository feedRepository;
     private final FcmTimerRepository fcmTimerRepository;
 
 
+    /**
+     * throw 모임이 존재하지 않는 경우
+     */
     public MeetingDetailResponseDto findMeetingDetail(Long requestId) {
         Meeting meeting = meetingRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
         FcmTimer certificationTime = fcmTimerRepository.findById(requestId).orElse(new FcmTimer(null, null));
         List<Participation> participations = meeting.getParticipations();
-        List<ParticipationDetailResponseDto> participationDetails = participations.stream()
-                .map(participation ->
-                        ParticipationDetailResponseDto.of(participation, participation.getUser(), participation.getFeed()))
-                .toList();
+        List<ParticipationDetailResponseDto> participationDetails = participations.stream().map(participation -> ParticipationDetailResponseDto.of(participation, participation.getUser(), participation.getFeed())).toList();
         return MeetingDetailResponseDto.of(meeting, certificationTime.getStartTime(), participationDetails);
     }
 

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -34,7 +34,7 @@ public class ParticipationService {
      */
     public ParticipationAvailabilityResponseDto findParticipationAvailability(Long requestId) {
         Meeting meeting = meetingRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if(!meetingService.isMeetingInDeadline(meeting) || meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
+        if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
         List<Participation> participations = meeting.getParticipations();
         if (hasUser(participations, requestId)) return null;
         return ParticipationAvailabilityResponseDto.of(meeting);
@@ -47,7 +47,7 @@ public class ParticipationService {
      */
     public ParticipationResponseDto createParticipation(User user, ParticipationReqeustDto reqeustDto) {
         Meeting meeting = meetingRepository.findById(reqeustDto.getMeetingId()).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if(!meetingService.isMeetingInDeadline(meeting) || meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
+        if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
         Participation participation = reqeustDto.toEntity(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
         participationRepository.save(participation);
         return ParticipationResponseDto.of(participation.getId());

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 플랫폼 타입입니다."),
     INVALID_FCM_UPLOAD(HttpStatus.BAD_REQUEST, "firebase 알람 전송에 실패했습니다."),
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 모임 시간입니다."),
+    INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/org/baggle/infra/redis/ExpirationListener.java
+++ b/src/main/java/org/baggle/infra/redis/ExpirationListener.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationService;
+import org.baggle.domain.fcm.service.FcmService;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import java.util.List;
 @Component
 public class ExpirationListener implements MessageListener {
     private final FcmNotificationService fcmNotificationService;
+    private final FcmService fcmService;
     private final FcmTimerRepository fcmTimerRepository;
 
     /**
@@ -35,7 +37,7 @@ public class ExpirationListener implements MessageListener {
             title = "긴급 소집!!";
         }
 
-        List<FcmToken> fcmTokens = fcmNotificationService.findFcmTokens(Long.parseLong(parts[1]));
+        List<FcmToken> fcmTokens = fcmService.findFcmTokens(Long.parseLong(parts[1]));
         // fcmNotificationService.sendNotificationByToken(FcmNotificationRequestDto.of(fcmTokens, title, body));
 
         System.out.println("########## onMessage message " + message.toString());


### PR DESCRIPTION
## Related Issue 🍃

close #29

## Description 🌴
- 사진 업로드 api에 긴급소집 이벤트 활성화 여부 및 모임 확정 여부에 따른 예외처리를 진행했습니다.
- 긴급 소집 알람 api에 모임 확정 여부에 따른 예외처리를 했습니다.
- fcmToken을 조회하는 메서드를 fcmNotificationService -> fcmService로 이동했습니다.
   -  추후) 특별한 작업이나 예외처리가 필요없는 경우 메서드를 삭제하고 다른 파일에서 fcmRepository를 import해 사용할 예정입니다.
