### PR TITLE
[feat] 애플 회원 가입 API 변경 사항 추가

### DIFF
--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -21,7 +21,7 @@ public class AuthApiController {
     @PostMapping("/signin")
     public ResponseEntity<BaseResponse<?>> signIn(@RequestHeader("Authorization") final String token,
                                                   @RequestBody final UserSignInRequestDto userSignInRequestDto) {
-        final UserAuthResponseDto userAuthResponseDto = authService.signin(token, userSignInRequestDto);
+        final UserAuthResponseDto userAuthResponseDto = authService.signIn(token, userSignInRequestDto);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, userAuthResponseDto));
     }
 
@@ -31,12 +31,12 @@ public class AuthApiController {
                                                   @RequestParam final String nickname,
                                                   @RequestParam final String platform,
                                                   @RequestParam final String fcmToken) {
-        final UserAuthResponseDto userAuthResponseDto = authService.signup(token, image, nickname, platform, fcmToken);
+        final UserAuthResponseDto userAuthResponseDto = authService.signUp(token, image, nickname, platform, fcmToken);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, userAuthResponseDto));
     }
 
     @GetMapping("/reissue")
-    public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader("Authorization") final String refreshToken) {
+    public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader("Authorization") final String refreshToken) {
         final Token reissuedToken = authService.reissue(refreshToken);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, reissuedToken));
     }

--- a/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
@@ -10,6 +10,7 @@ import org.baggle.global.config.jwt.Token;
 public class UserAuthResponseDto {
     private String accessToken;
     private String refreshToken;
+    private Long userId;
     private String platform;
     private String profileImageUrl;
     private String nickname;
@@ -18,6 +19,7 @@ public class UserAuthResponseDto {
         return UserAuthResponseDto.builder()
                 .accessToken(token.getAccessToken())
                 .refreshToken(token.getAccessToken())
+                .userId(user.getId())
                 .platform(user.getPlatform().getStringPlatform())
                 .profileImageUrl(user.getProfileImageUrl())
                 .nickname(user.getNickname())

--- a/src/main/java/org/baggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/baggle/domain/user/repository/UserRepository.java
@@ -7,5 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    List<User> findUsersByNickname(String nickname);
+
     List<User> findUsersByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -32,11 +32,12 @@ public class AuthService {
     private final AppleOAuthProvider appleOAuthProvider;
 
     // TODO
-    public UserAuthResponseDto signin(String token, UserSignInRequestDto userSignInRequestDto) {
+    public UserAuthResponseDto signIn(String token, UserSignInRequestDto userSignInRequestDto) {
         return null;
     }
 
-    public UserAuthResponseDto signup(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
+    public UserAuthResponseDto signUp(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
+        validateDuplicateNickname(nickname);
         Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
         String platformId = getPlatformIdFromToken(token, enumPlatform);
         validateDuplicateUser(enumPlatform, platformId);
@@ -51,6 +52,13 @@ public class AuthService {
     // TODO
     public Token reissue(String refreshToken) {
         return null;
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        List<User> findUsers = userRepository.findUsersByNickname(nickname);
+        if (!findUsers.isEmpty()) {
+            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+        }
     }
 
     private Platform getEnumPlatformFromStringPlatform(String platform) {

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
      */
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
 
     /**
      * 500 Internal Server Error


### PR DESCRIPTION
## Related Issue 🍃
close #28 

## Description 🌴
- 회원 가입 비즈니스 로직에 닉네임 중복 검사 기능을 추가하였습니다.
- 로그인 & 회원 가입 Response Dto에 userId 필드를 추가하였습니다.
