### PR TITLE
[fix] 애플 회원 가입 API 오류 수정

### DIFF
--- a/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
+++ b/src/main/java/org/baggle/domain/user/domain/RefreshToken.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.core.RedisHash;
 @AllArgsConstructor
 @Builder
 @Getter
-@RedisHash(value = "refreshToken", timeToLive = 60)
+@RedisHash(value = "refreshToken", timeToLive = 604800000)
 public class RefreshToken {
     @Id
     private Long id;

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -24,7 +24,7 @@ public class User extends BaseTimeEntity {
     private String nickname;
     @OneToMany(mappedBy = "user")
     private List<Participation> participations = new ArrayList<>();
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private FcmToken fcmToken;
     private String platformId;
     private String refreshToken;
@@ -33,7 +33,7 @@ public class User extends BaseTimeEntity {
 
     public static User createUserWithFcmToken(String profileImageUrl, String nickname, String fcmToken, String platformId, Platform platform) {
         User user = User.builder()
-                .profileImageUrl(profileImageUrl)
+                .profileImageUrl(!profileImageUrl.isEmpty() ? profileImageUrl : null)
                 .nickname(nickname)
                 .platformId(platformId)
                 .platform(platform)

--- a/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/response/UserAuthResponseDto.java
@@ -18,7 +18,7 @@ public class UserAuthResponseDto {
     public static UserAuthResponseDto of(Token token, User user) {
         return UserAuthResponseDto.builder()
                 .accessToken(token.getAccessToken())
-                .refreshToken(token.getAccessToken())
+                .refreshToken(token.getRefreshToken())
                 .userId(user.getId())
                 .platform(user.getPlatform().getStringPlatform())
                 .profileImageUrl(user.getProfileImageUrl())

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
         Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
         String platformId = getPlatformIdFromToken(token, enumPlatform);
         validateDuplicateUser(enumPlatform, platformId);
-        String profileImageUrl = uploadProfileImageToS3AndGetProfileImageUrl(image, ImageType.PROFILE);
+        String profileImageUrl = hasMultipartFile(image) ? uploadProfileImageToS3AndGetProfileImageUrl(image, ImageType.PROFILE) : "";
         User user = User.createUserWithFcmToken(profileImageUrl, nickname, fcmToken, platformId, enumPlatform);
         User savedUser = userRepository.save(user);
         Token issuedToken = jwtProvider.issueToken(savedUser.getId());
@@ -78,6 +78,10 @@ public class AuthService {
         if (!findUsers.isEmpty()) {
             throw new ConflictException(ErrorCode.DUPLICATE_USER);
         }
+    }
+
+    private boolean hasMultipartFile(MultipartFile multipartFile) {
+        return multipartFile != null && !multipartFile.isEmpty();
     }
 
     private void updateRefreshToken(User user, String refreshToken) {


### PR DESCRIPTION
## Related Issue 🍃
close #39 

## Description 🌴
- cascade 옵션을 설정하여 jpa persist 오류를 해결하였습니다.
- jwt signing key와 파싱 로직을 수정하였습니다.
- 로그인 & 회원가입 response dto에 refresh token getter가 잘못 설정되어 있던 부분을 수정하였습니다.
- redis에 저장되는 refresh token의 ttl을 변경하였습니다.
- 프로필 이미지 유무 판단 로직을 추가하여 프로필 사진이 없어도 회원 가입이 되도록 수정하였습니다.
