### PR TITLE
[feat] 1순위 api controller 구현

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -42,7 +42,6 @@ public class NotificationScheduler {
     @Scheduled(cron = "0 * * * * *")
     public void notificationScheduleTask() throws FirebaseMessagingException {
         FcmTimer certificationTime = fcmTimerRepository.findById(1L).orElse(new FcmTimer(null, null));
-        System.out.println(certificationTime.getStartTime());
         LocalDateTime now = LocalDateTime.now();
         List<Meeting> notificationMeeting = meetingService.findMeetingsInRange(now, 59, 60);
         for (Meeting m : notificationMeeting) {

--- a/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
@@ -48,7 +48,7 @@ public class FcmNotificationService {
     /**
      * TODO: 데이터 없을 시 예외 처리
      */
-    public void deleteFcmNotification(Long key){
+    public void deleteFcmNotification(Long key) {
         fcmNotificationRepository.deleteById(key);
     }
 
@@ -82,14 +82,14 @@ public class FcmNotificationService {
 
             try {
                 firebaseMessaging.send(message);
-            }catch (FirebaseMessagingException e){
+            } catch (FirebaseMessagingException e) {
                 log.error("Failed to send Notification", e);
                 throw new InvalidValueException(ErrorCode.INVALID_FCM_UPLOAD);
             }
         }
     }
 
-    public void createFcmTimer(Long key, LocalDateTime startTime){
+    public void createFcmTimer(Long key, LocalDateTime startTime) {
         FcmTimer fcmTimer = FcmTimer.builder()
                 .id(key)
                 .startTime(startTime)

--- a/src/main/java/org/baggle/domain/feed/controller/FeedController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedController.java
@@ -14,17 +14,16 @@ public class FeedController {
     private final FeedService feedService;
 
 //    @PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-//    public ResponseEntity<BaseResponse<?>> createFeedUpload(-----------------------,
-//                                                            @RequestBody FeedUploadRequestDto requestDto,
-//                                                            @RequestPart MultipartFile feedImage){
-//        FeedUploadResponseDto responseDto = feedService.feedUpload(requestDto, feedImage);
+//    public ResponseEntity<BaseResponse<?>> createFeedUpload(@RequestPart final FeedUploadRequestDto uploadInfo,
+//                                                            @RequestPart final MultipartFile feedImage) {
+//        final FeedUploadResponseDto responseDto = feedService.feedUpload(uploadInfo, feedImage);
 //        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
 //    }
-
-//    @GetMapping("/{member_id}")
-//    public ResponseEntity<BaseResponse<?>> uploadNotification(________________,
-//                                                              @PathVariable("member_id") Long memberId){
 //
+//    @GetMapping()
+//    public ResponseEntity<BaseResponse<?>> uploadNotification(@RequestParam final Long memberId,
+//                                                              @RequestParam final LocalDateTime authorizationTime) {
+//        final FeedNotificationResponseDto responseDto = feedService.uploadNotification(memberId, authorizationTime);
 //        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
 //    }
 

--- a/src/main/java/org/baggle/domain/feed/dto/request/FeedUploadRequestDto.java
+++ b/src/main/java/org/baggle/domain/feed/dto/request/FeedUploadRequestDto.java
@@ -10,5 +10,5 @@ import java.time.LocalDateTime;
 @Getter
 public class FeedUploadRequestDto {
     private Long participationId;
-    private LocalDateTime time;
+    private LocalDateTime authorizationTime;
 }

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -63,7 +63,7 @@ public class FeedService {
      * throw 모임에 참가자가 없는 경우
      * throw 모임이 확정되지 않은 경우
      */
-    public FeedNotificationResponseDto uploadNotification(Long requestId) {
+    public FeedNotificationResponseDto uploadNotification(Long requestId, LocalDateTime authorizationTime) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
         if (!meetingService.isValidTime(participation.getMeeting()))
             throw new InvalidValueException(INVALID_MEETING_TIME);
@@ -72,9 +72,8 @@ public class FeedService {
         FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
         fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto);
         // 이벤트 로직 5분 타이머를 시작하는 code 입니다.
-        LocalDateTime startTime = LocalDateTime.now();
-        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), startTime);
-        return FeedNotificationResponseDto.of(participation.getMeeting(), startTime);
+        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), authorizationTime);
+        return FeedNotificationResponseDto.of(participation.getMeeting(), authorizationTime);
     }
 
     /**

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -63,7 +63,7 @@ public class FeedService {
      * throw 모임에 참가자가 없는 경우
      * throw 모임이 확정되지 않은 경우
      */
-    public FeedNotificationResponseDto uploadNotification(Long requestId) {
+    public FeedNotificationResponseDto uploadNotification(Long requestId, LocalDateTime time) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
         if (!meetingService.isValidTime(participation.getMeeting()))
             throw new InvalidValueException(INVALID_MEETING_TIME);
@@ -72,9 +72,8 @@ public class FeedService {
         FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
         fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto);
         // 이벤트 로직 5분 타이머를 시작하는 code 입니다.
-        LocalDateTime startTime = LocalDateTime.now();
-        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), startTime);
-        return FeedNotificationResponseDto.of(participation.getMeeting(), startTime);
+        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), time);
+        return FeedNotificationResponseDto.of(participation.getMeeting(), time);
     }
 
     /**

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -63,7 +63,7 @@ public class FeedService {
      * throw 모임에 참가자가 없는 경우
      * throw 모임이 확정되지 않은 경우
      */
-    public FeedNotificationResponseDto uploadNotification(Long requestId, LocalDateTime time) {
+    public FeedNotificationResponseDto uploadNotification(Long requestId) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
         if (!meetingService.isValidTime(participation.getMeeting()))
             throw new InvalidValueException(INVALID_MEETING_TIME);
@@ -72,8 +72,9 @@ public class FeedService {
         FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
         fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto);
         // 이벤트 로직 5분 타이머를 시작하는 code 입니다.
-        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), time);
-        return FeedNotificationResponseDto.of(participation.getMeeting(), time);
+        LocalDateTime startTime = LocalDateTime.now();
+        fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), startTime);
+        return FeedNotificationResponseDto.of(participation.getMeeting(), startTime);
     }
 
     /**

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -1,8 +1,10 @@
 package org.baggle.domain.feed.service;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.fcm.domain.FcmTimer;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
+import org.baggle.domain.fcm.repository.FcmNotificationRepository;
 import org.baggle.domain.fcm.repository.FcmRepository;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationService;
@@ -23,8 +25,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import static org.baggle.global.error.exception.ErrorCode.*;
 
@@ -35,6 +39,7 @@ public class FeedService {
     private final ParticipationRepository participationRepository;
     private final FeedRepository feedRepository;
     private final S3Service s3Service;
+    private final FcmNotificationRepository fcmNotificationRepository;
     private final FcmNotificationService fcmNotificationService;
     private final FcmTimerRepository fcmTimerRepository;
     private final FcmRepository fcmRepository;
@@ -43,14 +48,11 @@ public class FeedService {
     /**
      * 피드를 업로드하는 메서드입니다.
      * throw 모임에 참가자가 없는 경우
-     * throw 모임이 확정되지 않은 경우
      * throw 긴급소집 이벤트가 진행 중이 아닌 경우
      */
     public FeedUploadResponseDto feedUpload(FeedUploadRequestDto requestDto, MultipartFile feedImage) {
         Participation participation = participationRepository.findById(requestDto.getParticipationId()).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
-        if (!meetingService.isValidTime(participation.getMeeting()))
-            throw new InvalidValueException(INVALID_MEETING_TIME);
-        if (!validateCertificationTime(participation.getMeeting()))
+        if (!validateCertificationTime(participation.getMeeting(), requestDto.getAuthorizationTime()))
             throw new InvalidValueException(INVALID_CERTIFICATION_TIME);
         String imgUrl = s3Service.uploadFile(feedImage, ImageType.FEED.getImageType());
         Feed feed = Feed.createParticipationWithFeedImg(participation, imgUrl);
@@ -61,17 +63,17 @@ public class FeedService {
     /**
      * 긴급소집 알람을 전송하는 api입니다.
      * throw 모임에 참가자가 없는 경우
-     * throw 모임이 확정되지 않은 경우
+     * throw 버튼 활성화 가능 시간이 아닌 경우
      */
     public FeedNotificationResponseDto uploadNotification(Long requestId, LocalDateTime authorizationTime) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
         if (!meetingService.isValidTime(participation.getMeeting()))
             throw new InvalidValueException(INVALID_MEETING_TIME);
-        // 알람을 broadcast 하는 code 입니다.
-        List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(participation.getMeeting().getId());
-        FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
-        fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto);
+        if (!validateNotificationTime(participation.getMeeting(), authorizationTime))
+            throw new InvalidValueException(INVALID_CERTIFICATION_TIME);
+//        broadcastNotification(participation.getMeeting());
         // 이벤트 로직 5분 타이머를 시작하는 code 입니다.
+        fcmNotificationService.deleteFcmNotification(participation.getMeeting().getId());
         fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), authorizationTime);
         return FeedNotificationResponseDto.of(participation.getMeeting(), authorizationTime);
     }
@@ -80,7 +82,23 @@ public class FeedService {
      * 긴급 소집 이벤트 활성화 여부를 확인하는 코드
      * return: 긴급 소집 이벤트 활성화시 True else False
      */
-    private Boolean validateCertificationTime(Meeting meeting) {
-        return fcmTimerRepository.existsById(meeting.getId());
+    private Boolean validateCertificationTime(Meeting meeting, LocalDateTime authorizationTime) {
+        FcmTimer fcmTimer = fcmTimerRepository.findById(meeting.getId()).orElse(null);
+        if (Objects.isNull(fcmTimer)) return Boolean.FALSE;
+        Duration duration = Duration.between(fcmTimer.getStartTime(), authorizationTime);
+        return 0 <= duration.toSeconds() && duration.toSeconds() <= 300;
+    }
+
+    private Boolean validateNotificationTime(Meeting meeting, LocalDateTime authorizationTime) {
+        LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
+        Duration duration = Duration.between(authorizationTime, meetingTime);
+        return 0 <= duration.toSeconds() && duration.toSeconds() <= 1800;
+
+    }
+
+    private void broadcastNotification(Meeting meeting) {
+        List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meeting.getId());
+        FcmNotificationRequestDto fcmNotificationRequestDto = FcmNotificationRequestDto.of(fcmTokens, "", "");
+        fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto);
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -16,7 +16,7 @@ public class MeetingController {
 //    @GetMapping("/detail")
 //    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@RequestParam final Long meetingId){
 //
-//        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(meetingId);
+//        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(, meetingId);
 //        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
 //    }
 

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -1,17 +1,10 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.domain.user.service.AuthService;
-import org.baggle.global.common.BaseResponse;
-import org.baggle.global.common.SuccessCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting")

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -1,10 +1,17 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting")
@@ -13,10 +20,10 @@ public class MeetingController {
     private final AuthService authService;
     private final MeetingService meetingService;
 
-//    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@RequestHeader("Authorization") final ________,
-//                                                             @PathVariable("meeting_id") final Long requestId){
+//    @GetMapping("/detail")
+//    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@RequestParam final Long meetingId){
 //
-//        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(requestId);
+//        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(meetingId);
 //        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
 //    }
 

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -1,10 +1,18 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.dto.reponse.ParticipationAvailabilityResponseDto;
+import org.baggle.domain.meeting.dto.reponse.ParticipationResponseDto;
+import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.service.ParticipationService;
 import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -13,19 +21,18 @@ public class ParticipationController {
     private final AuthService authService;
     private final ParticipationService participationService;
 
-/*    @GetMapping("/{meeting_id}")
-    public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@RequestHeader("Authorization") final ________,
-                                                                                                      @PathVariable("meeting_id") final Long requestId) {
-        ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(requestId);
-        if (Objects.isNull(responseDto))
-            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, null));
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-    }
-
-    @PostMapping("")
-    public ResponseEntity<BaseResponse<?>> createParticipation(@RequestHeader("Authorization") final ________,
-                                                                                      @RequestBody final ParticipationReqeustDto requestDto) {
-        ParticipationResponseDto responseDto = participationService.createParticipation(, requestDto);
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-    }*/
+//    @GetMapping()
+//    public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@RequestParam final Long meetingId) {
+//        final ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(, meetingId);
+//        if (Objects.isNull(responseDto))
+//            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, null));
+//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+//    }
+//
+//    @PostMapping()
+//    public ResponseEntity<BaseResponse<?>> createParticipation(@RequestBody final ParticipationReqeustDto requestDto) {
+//        System.out.println(requestDto);
+//        final ParticipationResponseDto responseDto = participationService.createParticipation(, requestDto);
+//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+//    }
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -1,18 +1,10 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.dto.reponse.ParticipationAvailabilityResponseDto;
-import org.baggle.domain.meeting.dto.reponse.ParticipationResponseDto;
-import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.service.ParticipationService;
 import org.baggle.domain.user.service.AuthService;
-import org.baggle.global.common.BaseResponse;
-import org.baggle.global.common.SuccessCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Objects;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -33,4 +33,14 @@ public class Participation extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ButtonAuthority buttonAuthority;
 
+    public static Participation createParticipationWithoutFeed(User user, Meeting meeting, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority, MeetingAuthority meetingAuthority){
+        return Participation.builder()
+                .user(user)
+                .meeting(meeting)
+                .participationMeetingStatus(participationMeetingStatus)
+                .buttonAuthority(buttonAuthority)
+                .meetingAuthority(meetingAuthority)
+                .build();
+    }
+
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -33,7 +33,7 @@ public class Participation extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ButtonAuthority buttonAuthority;
 
-    public static Participation createParticipationWithoutFeed(User user, Meeting meeting, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority, MeetingAuthority meetingAuthority){
+    public static Participation createParticipationWithoutFeed(User user, Meeting meeting, MeetingAuthority meetingAuthority, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority){
         return Participation.builder()
                 .user(user)
                 .meeting(meeting)

--- a/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
@@ -8,14 +8,4 @@ import org.baggle.domain.user.domain.User;
 @Getter
 public class ParticipationReqeustDto {
     private Long meetingId;
-
-    public Participation toEntity(User user, Meeting meeting, MeetingAuthority meetingAuthority, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority) {
-        return Participation.builder()
-                .user(user)
-                .meeting(meeting)
-                .participationMeetingStatus(participationMeetingStatus)
-                .buttonAuthority(buttonAuthority)
-                .meetingAuthority(meetingAuthority)
-                .build();
-    }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -3,7 +3,6 @@ package org.baggle.domain.meeting.service;
 import lombok.RequiredArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmTimer;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
-import org.baggle.domain.feed.repository.FeedRepository;
 import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
@@ -73,7 +72,6 @@ public class MeetingService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
         Duration duration = Duration.between(now, meetingTime);
-        System.out.println(duration.toMinutes());
         return duration.toMinutes() > 60;
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -73,6 +73,7 @@ public class MeetingService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
         Duration duration = Duration.between(now, meetingTime);
-        return Math.abs(duration.toMinutes()) > 60;
+        System.out.println(duration.toMinutes());
+        return duration.toMinutes() > 60;
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -35,7 +35,8 @@ public class ParticipationService {
      */
     public ParticipationAvailabilityResponseDto findParticipationAvailability(Long userId, Long requestId) {
         Meeting meeting = meetingRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
+        if (!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting))
+            throw new InvalidValueException(INVALID_MEETING_TIME);
         List<Participation> participations = meeting.getParticipations();
         if (duplicateParticipation(participations, userId)) return null;
         return ParticipationAvailabilityResponseDto.of(meeting);
@@ -50,8 +51,10 @@ public class ParticipationService {
     public ParticipationResponseDto createParticipation(Long userId, ParticipationReqeustDto reqeustDto) {
         Meeting meeting = meetingRepository.findById(reqeustDto.getMeetingId()).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
-        if (duplicateParticipation(meeting.getParticipations(), userId)) throw new InvalidValueException(DUPLICATE_PARTICIPATION);
+        if (!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting))
+            throw new InvalidValueException(INVALID_MEETING_TIME);
+        if (duplicateParticipation(meeting.getParticipations(), userId))
+            throw new InvalidValueException(DUPLICATE_PARTICIPATION);
         Participation participation = Participation.createParticipationWithoutFeed(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
         participationRepository.save(participation);
         return ParticipationResponseDto.of(participation.getId());
@@ -61,7 +64,6 @@ public class ParticipationService {
         return participations.stream()
                 .anyMatch(participation -> Objects.equals(participation.getUser().getId(), userId));
     }
-
 
 
 }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -8,6 +8,7 @@ import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.domain.user.domain.User;
+import org.baggle.domain.user.repository.UserRepository;
 import org.baggle.global.error.exception.EntityNotFoundException;
 import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.stereotype.Service;
@@ -16,8 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Objects;
 
-import static org.baggle.global.error.exception.ErrorCode.INVALID_MEETING_TIME;
-import static org.baggle.global.error.exception.ErrorCode.MEETING_NOT_FOUND;
+import static org.baggle.global.error.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -26,17 +26,18 @@ public class ParticipationService {
     private final MeetingRepository meetingRepository;
     private final ParticipationRepository participationRepository;
     private final MeetingService meetingService;
+    private final UserRepository userRepository;
 
     /**
      * 현재 모임에 참여 여부를 판단하는 메서드.
      * throw: 모임이 존재하지 않을 경우
      * throw: 2시간 내 모임이 존재하는 경우 or 모임시작 시간 < 1시간
      */
-    public ParticipationAvailabilityResponseDto findParticipationAvailability(Long requestId) {
+    public ParticipationAvailabilityResponseDto findParticipationAvailability(Long userId, Long requestId) {
         Meeting meeting = meetingRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
         if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
         List<Participation> participations = meeting.getParticipations();
-        if (hasUser(participations, requestId)) return null;
+        if (duplicateParticipation(participations, userId)) return null;
         return ParticipationAvailabilityResponseDto.of(meeting);
     }
 
@@ -44,16 +45,19 @@ public class ParticipationService {
      * 모임 참여 메서드
      * throw: 모임이 존재하지 않을 경우
      * throw: 2시간 내 모임이 존재하는 경우 or 모임시작 시간 < 1시간
+     * throw: 이미 모임에 참여한 경우
      */
-    public ParticipationResponseDto createParticipation(User user, ParticipationReqeustDto reqeustDto) {
+    public ParticipationResponseDto createParticipation(Long userId, ParticipationReqeustDto reqeustDto) {
         Meeting meeting = meetingRepository.findById(reqeustDto.getMeetingId()).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
         if(!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting)) throw new InvalidValueException(INVALID_MEETING_TIME);
-        Participation participation = reqeustDto.toEntity(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
+        if (duplicateParticipation(meeting.getParticipations(), userId)) throw new InvalidValueException(DUPLICATE_PARTICIPATION);
+        Participation participation = Participation.createParticipationWithoutFeed(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
         participationRepository.save(participation);
         return ParticipationResponseDto.of(participation.getId());
     }
 
-    private Boolean hasUser(List<Participation> participations, Long userId) {
+    private Boolean duplicateParticipation(List<Participation> participations, Long userId) {
         return participations.stream()
                 .anyMatch(participation -> Objects.equals(participation.getUser().getId(), userId));
     }

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 모임 시간입니다."),
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
 
+
     /**
      * 401 Unauthorized
      */
@@ -57,6 +58,7 @@ public enum ErrorCode {
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    DUPLICATE_PARTICIPATION(HttpStatus.CONFLICT, "이미 존재하는 참가자입니다."),
 
     /**
      * 500 Internal Server Error

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     INVALID_FCM_UPLOAD(HttpStatus.BAD_REQUEST, "firebase 알람 전송에 실패했습니다."),
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 모임 시간입니다."),
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
+    INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
 
 
     /**


### PR DESCRIPTION
## Related Issue 🍃

close #38 

## Description 🌴
- 1순위 api들 배포전 controller를 구현했습니다.
- controller 제작 후 postman을 통해 예외처리를 구체화 했습니다.
- 추가된 예외
  - 모임 상세 조회 : 모임 참여자가 아닌 경우
  - 긴급소집 알람 : 모임 종료 30분 전이 아닌경우
- 로직 수정
  - 시간 데이터 로직 수정 : 분 단위 연산 -> 초 단위 연산 
- 삭제한 예외
  - 피드 인증 : 모임 확정 여부 판단 -> 긴급 소집 이벤트 활성화 여부를 판단하는 예외가 있기 때문에 중복된 코드라 판단
  - 긴급 소집 알람 : 모임 확정 여부 판단 -> 모임 종료 30분 전인 경우를 판단하는 로직과 중복된 코드라 판단
