### PR TITLE
[feat] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
@@ -16,7 +16,6 @@ public class FcmToken extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "fcm_id")
     private Long id;
-    @Column(nullable = false)
     private String fcmToken;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenParser.java
+++ b/src/main/java/org/baggle/domain/user/auth/apple/IdentityTokenParser.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
-import lombok.extern.slf4j.Slf4j;
 import org.baggle.global.error.exception.ErrorCode;
 import org.baggle.global.error.exception.UnauthorizedException;
 import org.springframework.stereotype.Component;
@@ -14,7 +13,6 @@ import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Map;
 
-@Slf4j
 @Component
 public class IdentityTokenParser {
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -37,9 +35,6 @@ public class IdentityTokenParser {
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(ErrorCode.EXPIRED_IDENTITY_TOKEN);
         } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
-            log.info("identity token parser: ", e);
-            log.info("identity token: {}", identityToken);
-            log.info("public key: {}", publicKey);
             throw new UnauthorizedException(ErrorCode.INVALID_IDENTITY_TOKEN_VALUE);
         }
     }

--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -6,6 +6,7 @@ import org.baggle.domain.user.dto.response.UserAuthResponseDto;
 import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
+import org.baggle.global.config.auth.UserId;
 import org.baggle.global.config.jwt.Token;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -33,6 +34,12 @@ public class AuthApiController {
                                                   @RequestParam final String fcmToken) {
         final UserAuthResponseDto userAuthResponseDto = authService.signUp(token, image, nickname, platform, fcmToken);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, userAuthResponseDto));
+    }
+
+    @PatchMapping("/withdraw")
+    public ResponseEntity<BaseResponse<?>> withdraw(@UserId final Long userId) {
+        authService.withdraw(userId);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, null));
     }
 
     @GetMapping("/reissue")

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -45,6 +45,15 @@ public class User extends BaseTimeEntity {
         return user;
     }
 
+    public void withdrawUser() {
+        this.profileImageUrl = null;
+        this.nickname = null;
+        this.fcmToken.updateFcmToken(null);
+        this.platformId = null;
+        this.refreshToken = null;
+        this.platform = Platform.WITHDRAW;
+    }
+
     public void changeFcmToken(FcmToken fcmToken) {
         this.fcmToken = fcmToken;
     }

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -13,6 +13,7 @@ import org.baggle.global.common.ImageType;
 import org.baggle.global.config.jwt.JwtProvider;
 import org.baggle.global.config.jwt.Token;
 import org.baggle.global.error.exception.ConflictException;
+import org.baggle.global.error.exception.EntityNotFoundException;
 import org.baggle.global.error.exception.ErrorCode;
 import org.baggle.infra.s3.S3Service;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,13 @@ public class AuthService {
         Token issuedToken = jwtProvider.issueToken(savedUser.getId());
         updateRefreshToken(savedUser, issuedToken.getRefreshToken());
         return UserAuthResponseDto.of(issuedToken, savedUser);
+    }
+
+    public void withdraw(Long userId) {
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        findUser.withdrawUser();
+        refreshTokenRepository.deleteById(userId);
     }
 
     // TODO

--- a/src/main/java/org/baggle/global/config/WebConfig.java
+++ b/src/main/java/org/baggle/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package org.baggle.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.config.auth.UserIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
+    }
+}

--- a/src/main/java/org/baggle/global/config/auth/ExceptionHandlerFilter.java
+++ b/src/main/java/org/baggle/global/config/auth/ExceptionHandlerFilter.java
@@ -23,16 +23,14 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (UnauthorizedException | InvalidValueException e) {
-            log.error("filter exception: ", e);
-            handleJwtException(response, e);
+        } catch (UnauthorizedException e) {
+            handleUnauthorizedException(response, e);
         } catch (Exception ee) {
-            log.error("filter exception: ", ee);
             handleException(response);
         }
     }
 
-    private void handleJwtException(HttpServletResponse response, Exception e) throws IOException {
+    private void handleUnauthorizedException(HttpServletResponse response, Exception e) throws IOException {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
         if (e instanceof UnauthorizedException ue) {

--- a/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtProvider jwtProvider;
     // TODO api 추가될 때 white list url 확인해서 추가하기.
-    private static final String[] whiteList = {"/api/user/signin", "/api/user/signup", "/api/user/reissue"};
+    private static final String[] whiteList = {"/api/user/signin", "/api/user/signup", "/api/user/reissue", "/error"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {

--- a/src/main/java/org/baggle/global/config/auth/UserId.java
+++ b/src/main/java/org/baggle/global/config/auth/UserId.java
@@ -1,0 +1,11 @@
+package org.baggle.global.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/org/baggle/global/config/auth/UserIdArgumentResolver.java
+++ b/src/main/java/org/baggle/global/config/auth/UserIdArgumentResolver.java
@@ -1,0 +1,26 @@
+package org.baggle.global.config.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
+        boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasUserIdAnnotation && hasLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+    }
+}

--- a/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
+++ b/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
@@ -2,9 +2,9 @@ package org.baggle.global.config.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.Getter;
 import org.baggle.global.error.exception.ErrorCode;
-import org.baggle.global.error.exception.InvalidValueException;
 import org.baggle.global.error.exception.UnauthorizedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -42,20 +42,20 @@ public class JwtProvider {
     public void validateAccessToken(String accessToken) {
         try {
             getJwtParser().parseClaimsJws(accessToken);
-        } catch (JwtException e) {
-            throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN);
-        } catch (IllegalArgumentException ee) {
-            throw new InvalidValueException(ErrorCode.BAD_REQUEST);
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         }
     }
 
     public void validateRefreshToken(String refreshToken) {
         try {
             getJwtParser().parseClaimsJws(refreshToken);
-        } catch (JwtException e) {
-            throw new UnauthorizedException(ErrorCode.INVALID_REFRESH_TOKEN);
-        } catch (IllegalArgumentException ee) {
-            throw new InvalidValueException(ErrorCode.BAD_REQUEST);
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_REFRESH_TOKEN_VALUE);
         }
     }
 

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -20,14 +20,17 @@ public enum ErrorCode {
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
 
-
     /**
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
-    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 엑세스 토큰입니다."),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 액세스 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요."),
+    INVALID_ACCESS_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "액세스 토큰의 값이 올바르지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 형식이 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 값이 올바르지 않습니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
     INVALID_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "애플 아이덴터티 토큰의 형식이 올바르지 않습니다."),
     INVALID_IDENTITY_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "애플 아이덴터티 토큰의 값이 올바르지 않습니다."),
@@ -43,10 +46,11 @@ public enum ErrorCode {
     /**
      * 404 Not Found
      */
-    ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "엔티티를 찾을 수 없습니다."),
-    FCM_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "FCM 토큰을 찾을 수 없습니다."),
-    MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "모임 정보를 찾을 수 없습니다."),
-    PARTICIPATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "모임 참가자를 찾을 수 없습니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM 토큰을 찾을 수 없습니다."),
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 정보를 찾을 수 없습니다."),
+    PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 참가자를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/resources/db/migration/V3__modify_table.sql
+++ b/src/main/resources/db/migration/V3__modify_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE fcm DROP COLUMN fcm_token;
+ALTER TABLE fcm ADD COLUMN fcm_token VARCHAR(255);


### PR DESCRIPTION
## Related Issue 🍃
close #42 

## Description 🌴
- 회원 탈퇴 API를 구현하였습니다.
- 탈퇴 후 익명 데이터를 남기기 위해 회원 엔티티 삭제가 아닌 값 변경 방식을 선택하였습니다.
- 프로필 이미지, 닉네임, 플렛폼 고유 코드, Refresh 토큰(Redis Refresh 토큰은 삭제 처리하였습니다.), FCM 토큰을 null 값으로 변경하고 플랫폼을 WITHDRAW로 바꾸어 회원 탈퇴 처리를 하였습니다.
- FCM 토큰을 null 값으로 변경하기 위해 기존에 걸려있던 NOT NULL 제약 조건을 제거했습니다.
- @UserId 커스텀 애노테이션과 UserIdArgumentResolver를 구현하였습니다. `@UserId final Long userId`로 Access 토큰에 포함된 userId 값을 편리하게 사용할 수 있습니다.
- V3 sql 파일을 생성하였고 해당 파일에 맞게 RDS 데이터베이스 테이블을 변경하였습니다.
- 인증 관련 오류 코드를 자세하게 나누어 핸들링하도록 리팩터링하였습니다.
