### PR TITLE
[feat] 애플 로그인 API 구현

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmToken.java
@@ -21,12 +21,12 @@ public class FcmToken extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public void updateFcmToken(String fcmToken) {
-        this.fcmToken = fcmToken;
-    }
-
     public void changeUser(User user) {
         this.user = user;
-        user.changeFcmToken(this);
+        user.updateFcmToken(this);
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/org/baggle/domain/fcm/repository/FcmRepository.java
+++ b/src/main/java/org/baggle/domain/fcm/repository/FcmRepository.java
@@ -8,13 +8,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FcmRepository extends JpaRepository<FcmToken, Long> {
-
     FcmToken findByUser(User user);
 
-    FcmToken findByUserId(Long userId);
+    Optional<FcmToken> findByUserId(Long userId);
 
     Optional<FcmToken> findByFcmToken(String fcmToken);
 
     List<FcmToken> findByUserParticipationsMeetingId(Long meetingId);
-
 }

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -54,7 +54,7 @@ public class User extends BaseTimeEntity {
         this.platform = Platform.WITHDRAW;
     }
 
-    public void changeFcmToken(FcmToken fcmToken) {
+    public void updateFcmToken(FcmToken fcmToken) {
         this.fcmToken = fcmToken;
     }
 

--- a/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/request/UserSignInRequestDto.java
@@ -1,6 +1,5 @@
 package org.baggle.domain.user.dto.request;
 
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/org/baggle/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/baggle/domain/user/repository/UserRepository.java
@@ -5,9 +5,12 @@ import org.baggle.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findUsersByNickname(String nickname);
+
+    Optional<User> findUserByPlatformAndPlatformId(Platform platform, String platformId);
 
     List<User> findUsersByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -1,6 +1,8 @@
 package org.baggle.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.fcm.domain.FcmToken;
+import org.baggle.domain.fcm.repository.FcmRepository;
 import org.baggle.domain.user.auth.apple.AppleOAuthProvider;
 import org.baggle.domain.user.domain.Platform;
 import org.baggle.domain.user.domain.RefreshToken;
@@ -28,33 +30,29 @@ import java.util.List;
 public class AuthService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final FcmRepository fcmRepository;
     private final S3Service s3Service;
     private final JwtProvider jwtProvider;
     private final AppleOAuthProvider appleOAuthProvider;
 
-    // TODO
     public UserAuthResponseDto signIn(String token, UserSignInRequestDto userSignInRequestDto) {
-        return null;
+        User findUser = getUser(token, userSignInRequestDto);
+        updateFcmToken(userSignInRequestDto.getFcmToken(), findUser);
+        Token issuedToken = issueAccessTokenAndRefreshToken(findUser);
+        return UserAuthResponseDto.of(issuedToken, findUser);
     }
 
     public UserAuthResponseDto signUp(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
-        validateDuplicateNickname(nickname);
-        Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
-        String platformId = getPlatformIdFromToken(token, enumPlatform);
-        validateDuplicateUser(enumPlatform, platformId);
-        String profileImageUrl = hasMultipartFile(image) ? uploadProfileImageToS3AndGetProfileImageUrl(image, ImageType.PROFILE) : "";
-        User user = User.createUserWithFcmToken(profileImageUrl, nickname, fcmToken, platformId, enumPlatform);
-        User savedUser = userRepository.save(user);
-        Token issuedToken = jwtProvider.issueToken(savedUser.getId());
+        User savedUser = validateUserAndSaveUser(token, image, nickname, platform, fcmToken);
+        Token issuedToken = issueAccessTokenAndRefreshToken(savedUser);
         updateRefreshToken(savedUser, issuedToken.getRefreshToken());
         return UserAuthResponseDto.of(issuedToken, savedUser);
     }
 
     public void withdraw(Long userId) {
-        User findUser = userRepository.findById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        User findUser = getUser(userId);
         findUser.withdrawUser();
-        refreshTokenRepository.deleteById(userId);
+        deleteRefreshToken(userId);
     }
 
     // TODO
@@ -62,11 +60,42 @@ public class AuthService {
         return null;
     }
 
-    private void validateDuplicateNickname(String nickname) {
-        List<User> findUsers = userRepository.findUsersByNickname(nickname);
-        if (!findUsers.isEmpty()) {
-            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
-        }
+    private User getUser(String token, UserSignInRequestDto userSignInRequestDto) {
+        Platform enumPlatform = getEnumPlatformFromStringPlatform(userSignInRequestDto.getPlatform());
+        String platformId = getPlatformIdFromToken(token, enumPlatform);
+        return getUserByPlatformAndPlatformId(enumPlatform, platformId);
+    }
+
+    private User getUser(Long userId) {
+        return getUserById(userId);
+    }
+
+    private void deleteRefreshToken(Long userId) {
+        refreshTokenRepository.deleteById(userId);
+    }
+
+    private void updateFcmToken(String fcmToken, User user) {
+        FcmToken findFcmToken = getFcmTokenByUserId(user.getId());
+        findFcmToken.updateFcmToken(fcmToken);
+    }
+
+    private User validateUserAndSaveUser(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
+        validateDuplicateNickname(nickname);
+        Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
+        String platformId = getPlatformIdFromToken(token, enumPlatform);
+        validateDuplicateUser(enumPlatform, platformId);
+        String profileImageUrl = hasMultipartFile(image) ? uploadProfileImageToS3AndGetProfileImageUrl(image, ImageType.PROFILE) : "";
+        User user = User.createUserWithFcmToken(profileImageUrl, nickname, fcmToken, platformId, enumPlatform);
+        return userRepository.save(user);
+    }
+
+    private Token issueAccessTokenAndRefreshToken(User user) {
+        return jwtProvider.issueToken(user.getId());
+    }
+
+    private void updateRefreshToken(User user, String refreshToken) {
+        user.updateRefreshToken(refreshToken);
+        refreshTokenRepository.save(RefreshToken.createRefreshToken(user.getId(), refreshToken));
     }
 
     private Platform getEnumPlatformFromStringPlatform(String platform) {
@@ -81,6 +110,28 @@ public class AuthService {
         return appleOAuthProvider.getApplePlatformId(token);
     }
 
+    private User getUserByPlatformAndPlatformId(Platform platform, String platformId) {
+        return userRepository.findUserByPlatformAndPlatformId(platform, platformId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private FcmToken getFcmTokenByUserId(Long userId) {
+        return fcmRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND));
+    }
+
+    private void validateDuplicateNickname(String nickname) {
+        List<User> findUsers = userRepository.findUsersByNickname(nickname);
+        if (!findUsers.isEmpty()) {
+            throw new ConflictException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+
     private void validateDuplicateUser(Platform platform, String platformId) {
         List<User> findUsers = userRepository.findUsersByPlatformAndPlatformId(platform, platformId);
         if (!findUsers.isEmpty()) {
@@ -90,11 +141,6 @@ public class AuthService {
 
     private boolean hasMultipartFile(MultipartFile multipartFile) {
         return multipartFile != null && !multipartFile.isEmpty();
-    }
-
-    private void updateRefreshToken(User user, String refreshToken) {
-        user.updateRefreshToken(refreshToken);
-        refreshTokenRepository.save(RefreshToken.createRefreshToken(user.getId(), refreshToken));
     }
 
     private String uploadProfileImageToS3AndGetProfileImageUrl(MultipartFile image, ImageType imageType) {

--- a/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/baggle/global/config/auth/SecurityConfig.java
@@ -19,7 +19,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtProvider jwtProvider;
     // TODO api 추가될 때 white list url 확인해서 추가하기.
-    private static final String[] whiteList = {"/api/user/signin", "/api/user/signup", "/api/user/reissue", "/error"};
+    private static final String[] whiteList = {"/api/user/signin", "/api/user/signup", "/api/user/reissue", "/error", "/"};
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {


### PR DESCRIPTION
## Related Issue 🍃
close #44 

## Description 🌴
- 애플 로그인 비즈니스 로직을 구현하였습니다.
- 로그인 & 회원 가입 & 회원 탈퇴 비즈니스 로직을 리팩터링 하였습니다.
- health check URL을 security config white list에 추가하였습니다.
