### PR TITLE
[fix] 회원 탈퇴 API 반환 값 변경

### DIFF
--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -39,7 +39,7 @@ public class AuthApiController {
     @PatchMapping("/withdraw")
     public ResponseEntity<BaseResponse<?>> withdraw(@UserId final Long userId) {
         authService.withdraw(userId);
-        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, null));
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, true));
     }
 
     @GetMapping("/reissue")

--- a/src/main/java/org/baggle/domain/user/service/AuthService.java
+++ b/src/main/java/org/baggle/domain/user/service/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
     }
 
     public UserAuthResponseDto signUp(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
-        User savedUser = validateUserAndSaveUser(token, image, nickname, platform, fcmToken);
+        User savedUser = validateAndSaveUser(token, image, nickname, platform, fcmToken);
         Token issuedToken = issueAccessTokenAndRefreshToken(savedUser);
         updateRefreshToken(savedUser, issuedToken.getRefreshToken());
         return UserAuthResponseDto.of(issuedToken, savedUser);
@@ -79,7 +79,7 @@ public class AuthService {
         findFcmToken.updateFcmToken(fcmToken);
     }
 
-    private User validateUserAndSaveUser(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
+    private User validateAndSaveUser(String token, MultipartFile image, String nickname, String platform, String fcmToken) {
         validateDuplicateNickname(nickname);
         Platform enumPlatform = getEnumPlatformFromStringPlatform(platform);
         String platformId = getPlatformIdFromToken(token, enumPlatform);


### PR DESCRIPTION
## Related Issue 🍃
close #47 

## Description 🌴
- 회원 탈퇴 API 반환 값을 null -> true로 변경하였습니다.
- validateUserAndSaveUser -> validateAndSaveUser로 메서드명을 수정하였습니다.
