### PR TITLE
[fix] 링크 참여 api 예외처리 개선

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -17,7 +17,7 @@ public class ParticipationController {
 //    public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@RequestParam final Long meetingId) {
 //        final ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(, meetingId);
 //        if (Objects.isNull(responseDto))
-//            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, null));
+//            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, true));
 //        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
 //    }
 //

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -53,6 +53,8 @@ public class ParticipationService {
             throw new InvalidValueException(INVALID_MEETING_TIME);
         if (duplicateParticipation(meeting.getParticipations(), userId))
             throw new InvalidValueException(DUPLICATE_PARTICIPATION);
+        if (!validateMeetingCapacity(meeting))
+            throw new InvalidValueException(INVALID_MEETING_CAPACITY);
         Participation participation = Participation.createParticipationWithoutFeed(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
         participationRepository.save(participation);
         return ParticipationResponseDto.of(participation.getId());
@@ -61,6 +63,10 @@ public class ParticipationService {
     private Boolean duplicateParticipation(List<Participation> participations, Long userId) {
         return participations.stream()
                 .anyMatch(participation -> Objects.equals(participation.getUser().getId(), userId));
+    }
+
+    private Boolean validateMeetingCapacity(Meeting meeting) {
+        return !(meeting.getParticipations().size() == 6);
     }
 
 

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -31,12 +31,9 @@ public class ParticipationService {
     /**
      * 현재 모임에 참여 여부를 판단하는 메서드.
      * throw: 모임이 존재하지 않을 경우
-     * throw: 2시간 내 모임이 존재하는 경우 or 모임시작 시간 < 1시간
      */
     public ParticipationAvailabilityResponseDto findParticipationAvailability(Long userId, Long requestId) {
         Meeting meeting = meetingRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if (!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting))
-            throw new InvalidValueException(INVALID_MEETING_TIME);
         List<Participation> participations = meeting.getParticipations();
         if (duplicateParticipation(participations, userId)) return null;
         return ParticipationAvailabilityResponseDto.of(meeting);
@@ -47,6 +44,7 @@ public class ParticipationService {
      * throw: 모임이 존재하지 않을 경우
      * throw: 2시간 내 모임이 존재하는 경우 or 모임시작 시간 < 1시간
      * throw: 이미 모임에 참여한 경우
+     * throw: 모임이 다 찼을 경우
      */
     public ParticipationResponseDto createParticipation(Long userId, ParticipationReqeustDto reqeustDto) {
         Meeting meeting = meetingRepository.findById(reqeustDto.getMeetingId()).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 모임 시간입니다."),
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
+    INVALID_MEETING_CAPACITY(HttpStatus.BAD_REQUEST, "모임 인원이 초과됐습니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
## Related Issue 🍃\

close #45 

## Description 🌴
- 링크 참여와 관련된 api에서 중복된 예외처리를 제거하였습니다.
- 모임 인원이 초과했을 경우 예외처리 코드를 작성했습니다.
- 추가적으로 이미 모임에 참여했을 경우 null -> True를 전달하도록 변경하였습니다.
