### PR TITLE
[feat] 모임 수정 api 구현 & 1순위 api 배포

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/domain/FcmTimer.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmTimer.java
@@ -16,4 +16,11 @@ public class FcmTimer {
     @Id
     private Long id;
     private LocalDateTime startTime;
+
+    public static FcmTimer getFcmTimerWithNull(){
+        return FcmTimer.builder()
+                .id(null)
+                .startTime(null)
+                .build();
+    }
 }

--- a/src/main/java/org/baggle/domain/fcm/domain/FcmTimer.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmTimer.java
@@ -17,7 +17,7 @@ public class FcmTimer {
     private Long id;
     private LocalDateTime startTime;
 
-    public static FcmTimer getFcmTimerWithNull(){
+    public static FcmTimer createFcmTimerWithNull(){
         return FcmTimer.builder()
                 .id(null)
                 .startTime(null)

--- a/src/main/java/org/baggle/domain/fcm/dto/request/AddFcmTokenRequestDto.java
+++ b/src/main/java/org/baggle/domain/fcm/dto/request/AddFcmTokenRequestDto.java
@@ -1,9 +1,11 @@
 package org.baggle.domain.fcm.dto.request;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.user.domain.User;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class AddFcmTokenRequestDto {
     private String fcmToken;

--- a/src/main/java/org/baggle/domain/fcm/dto/request/FcmNotificationRequestDto.java
+++ b/src/main/java/org/baggle/domain/fcm/dto/request/FcmNotificationRequestDto.java
@@ -7,9 +7,8 @@ import lombok.NoArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmToken;
 
 import java.util.List;
-
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class FcmNotificationRequestDto {
     private List<FcmToken> targetTokenList;
     private String title;

--- a/src/main/java/org/baggle/domain/fcm/dto/request/UpdateFcmTokenRequestDto.java
+++ b/src/main/java/org/baggle/domain/fcm/dto/request/UpdateFcmTokenRequestDto.java
@@ -1,7 +1,10 @@
 package org.baggle.domain.fcm.dto.request;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class UpdateFcmTokenRequestDto {
     private String beforeFCMToken;

--- a/src/main/java/org/baggle/domain/feed/controller/FeedApiController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedApiController.java
@@ -5,7 +5,6 @@ import org.baggle.domain.feed.dto.request.FeedUploadRequestDto;
 import org.baggle.domain.feed.dto.response.FeedNotificationResponseDto;
 import org.baggle.domain.feed.dto.response.FeedUploadResponseDto;
 import org.baggle.domain.feed.service.FeedService;
-import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.springframework.http.MediaType;
@@ -19,7 +18,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 @RequestMapping("/api/feed")
 @Controller
-public class FeedController {
+public class FeedApiController {
     private final FeedService feedService;
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/org/baggle/domain/feed/controller/FeedController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedController.java
@@ -30,7 +30,7 @@ public class FeedController {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<BaseResponse<?>> uploadNotification(@RequestParam final Long memberId,
                                                               @RequestParam final LocalDateTime authorizationTime) {
         final FeedNotificationResponseDto responseDto = feedService.uploadNotification(memberId, authorizationTime);

--- a/src/main/java/org/baggle/domain/feed/controller/FeedController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedController.java
@@ -1,10 +1,20 @@
 package org.baggle.domain.feed.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.feed.dto.request.FeedUploadRequestDto;
+import org.baggle.domain.feed.dto.response.FeedNotificationResponseDto;
+import org.baggle.domain.feed.dto.response.FeedUploadResponseDto;
 import org.baggle.domain.feed.service.FeedService;
 import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/feed")
@@ -13,18 +23,18 @@ public class FeedController {
     private final AuthService authService;
     private final FeedService feedService;
 
-//    @PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-//    public ResponseEntity<BaseResponse<?>> createFeedUpload(@RequestPart final FeedUploadRequestDto uploadInfo,
-//                                                            @RequestPart final MultipartFile feedImage) {
-//        final FeedUploadResponseDto responseDto = feedService.feedUpload(uploadInfo, feedImage);
-//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-//    }
-//
-//    @GetMapping()
-//    public ResponseEntity<BaseResponse<?>> uploadNotification(@RequestParam final Long memberId,
-//                                                              @RequestParam final LocalDateTime authorizationTime) {
-//        final FeedNotificationResponseDto responseDto = feedService.uploadNotification(memberId, authorizationTime);
-//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-//    }
+    @PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<BaseResponse<?>> createFeedUpload(@RequestPart final FeedUploadRequestDto uploadInfo,
+                                                            @RequestPart final MultipartFile feedImage) {
+        final FeedUploadResponseDto responseDto = feedService.feedUpload(uploadInfo, feedImage);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
+
+    @GetMapping()
+    public ResponseEntity<BaseResponse<?>> uploadNotification(@RequestParam final Long memberId,
+                                                              @RequestParam final LocalDateTime authorizationTime) {
+        final FeedNotificationResponseDto responseDto = feedService.uploadNotification(memberId, authorizationTime);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
 
 }

--- a/src/main/java/org/baggle/domain/feed/controller/FeedController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedController.java
@@ -23,7 +23,7 @@ public class FeedController {
     private final AuthService authService;
     private final FeedService feedService;
 
-    @PostMapping(value = "", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<BaseResponse<?>> createFeedUpload(@RequestPart final FeedUploadRequestDto uploadInfo,
                                                             @RequestPart final MultipartFile feedImage) {
         final FeedUploadResponseDto responseDto = feedService.feedUpload(uploadInfo, feedImage);

--- a/src/main/java/org/baggle/domain/feed/controller/FeedController.java
+++ b/src/main/java/org/baggle/domain/feed/controller/FeedController.java
@@ -20,7 +20,6 @@ import java.time.LocalDateTime;
 @RequestMapping("/api/feed")
 @Controller
 public class FeedController {
-    private final AuthService authService;
     private final FeedService feedService;
 
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmTimer;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
-import org.baggle.domain.fcm.repository.FcmNotificationRepository;
 import org.baggle.domain.fcm.repository.FcmRepository;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationService;
@@ -17,7 +16,6 @@ import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
-import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.global.common.ImageType;
 import org.baggle.global.error.exception.EntityNotFoundException;
 import org.baggle.global.error.exception.InvalidValueException;
@@ -40,11 +38,9 @@ public class FeedService {
     private final ParticipationRepository participationRepository;
     private final FeedRepository feedRepository;
     private final S3Service s3Service;
-    private final FcmNotificationRepository fcmNotificationRepository;
     private final FcmNotificationService fcmNotificationService;
     private final FcmTimerRepository fcmTimerRepository;
     private final FcmRepository fcmRepository;
-    private final MeetingService meetingService;
 
     /**
      * 피드를 업로드하는 메서드입니다.

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -14,6 +14,7 @@ import org.baggle.domain.feed.dto.response.FeedNotificationResponseDto;
 import org.baggle.domain.feed.dto.response.FeedUploadResponseDto;
 import org.baggle.domain.feed.repository.FeedRepository;
 import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.domain.meeting.service.MeetingService;
@@ -67,7 +68,7 @@ public class FeedService {
      */
     public FeedNotificationResponseDto uploadNotification(Long requestId, LocalDateTime authorizationTime) {
         Participation participation = participationRepository.findById(requestId).orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
-        if (!meetingService.isValidTime(participation.getMeeting()))
+        if (participation.getMeeting().getMeetingStatus() != MeetingStatus.SCHEDULED)
             throw new InvalidValueException(INVALID_MEETING_TIME);
         if (!validateNotificationTime(participation.getMeeting(), authorizationTime))
             throw new InvalidValueException(INVALID_CERTIFICATION_TIME);

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
@@ -5,7 +5,6 @@ import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.service.MeetingService;
-import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
@@ -16,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting")
 @Controller
-public class MeetingController {
+public class MeetingApiController {
     private final MeetingService meetingService;
 
     @GetMapping("/detail")

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -1,10 +1,17 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.baggle.global.config.auth.UserId;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting")
@@ -13,11 +20,12 @@ public class MeetingController {
     private final AuthService authService;
     private final MeetingService meetingService;
 
-//    @GetMapping("/detail")
-//    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@RequestParam final Long meetingId){
-//
-//        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(, meetingId);
-//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-//    }
+    @GetMapping("/detail")
+    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId Long userId,
+                                                             @RequestParam final Long meetingId){
+
+        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(userId, meetingId);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
 
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -27,7 +27,7 @@ public class MeetingController {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 
-    @PatchMapping("")
+    @PatchMapping()
     public ResponseEntity<BaseResponse<?>> updateMeetingInfo(@UserId final Long userId,
                                                              @RequestBody final UpdateMeetingInfoRequestDto requestDto) {
         final UpdateMeetingInfoResponseDto responseDto = meetingService.updateMeetingInfo(userId, requestDto);

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -1,8 +1,8 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
-import org.baggle.domain.meeting.dto.reponse.UpdateMeetingInfoResponseDto;
+import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
+import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.domain.user.service.AuthService;
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/meeting")
 @Controller
 public class MeetingController {
-    private final AuthService authService;
     private final MeetingService meetingService;
 
     @GetMapping("/detail")

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -27,7 +27,7 @@ public class MeetingController {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 
-    @PatchMapping()
+    @PatchMapping
     public ResponseEntity<BaseResponse<?>> updateMeetingInfo(@UserId final Long userId,
                                                              @RequestBody final UpdateMeetingInfoRequestDto requestDto) {
         final UpdateMeetingInfoResponseDto responseDto = meetingService.updateMeetingInfo(userId, requestDto);

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingController.java
@@ -2,6 +2,8 @@ package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
+import org.baggle.domain.meeting.dto.reponse.UpdateMeetingInfoResponseDto;
+import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
@@ -9,9 +11,7 @@ import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting")
@@ -21,10 +21,16 @@ public class MeetingController {
     private final MeetingService meetingService;
 
     @GetMapping("/detail")
-    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId Long userId,
-                                                             @RequestParam final Long meetingId){
-
+    public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId final Long userId,
+                                                             @RequestParam final Long meetingId) {
         MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(userId, meetingId);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<BaseResponse<?>> updateMeetingInfo(@UserId final Long userId,
+                                                             @RequestBody final UpdateMeetingInfoRequestDto requestDto) {
+        final UpdateMeetingInfoResponseDto responseDto = meetingService.updateMeetingInfo(userId, requestDto);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
@@ -5,7 +5,6 @@ import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseD
 import org.baggle.domain.meeting.dto.response.ParticipationResponseDto;
 import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.service.ParticipationService;
-import org.baggle.domain.user.service.AuthService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
@@ -18,7 +17,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
 @Controller
-public class ParticipationController {
+public class ParticipationApiController {
     private final ParticipationService participationService;
 
     @GetMapping

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -1,8 +1,8 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.dto.reponse.ParticipationAvailabilityResponseDto;
-import org.baggle.domain.meeting.dto.reponse.ParticipationResponseDto;
+import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseDto;
+import org.baggle.domain.meeting.dto.response.ParticipationResponseDto;
 import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.service.ParticipationService;
 import org.baggle.domain.user.service.AuthService;
@@ -19,7 +19,6 @@ import java.util.Objects;
 @RequestMapping("/api/member")
 @Controller
 public class ParticipationController {
-    private final AuthService authService;
     private final ParticipationService participationService;
 
     @GetMapping

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -1,10 +1,19 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.dto.reponse.ParticipationAvailabilityResponseDto;
+import org.baggle.domain.meeting.dto.reponse.ParticipationResponseDto;
+import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.service.ParticipationService;
 import org.baggle.domain.user.service.AuthService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.baggle.global.config.auth.UserId;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/member")
@@ -13,18 +22,19 @@ public class ParticipationController {
     private final AuthService authService;
     private final ParticipationService participationService;
 
-//    @GetMapping()
-//    public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@RequestParam final Long meetingId) {
-//        final ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(, meetingId);
-//        if (Objects.isNull(responseDto))
-//            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, true));
-//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-//    }
-//
-//    @PostMapping()
-//    public ResponseEntity<BaseResponse<?>> createParticipation(@RequestBody final ParticipationReqeustDto requestDto) {
-//        System.out.println(requestDto);
-//        final ParticipationResponseDto responseDto = participationService.createParticipation(, requestDto);
-//        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
-//    }
+    @GetMapping()
+    public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@UserId final Long userId,
+                                                                   @RequestParam final Long meetingId) {
+        final ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(userId, meetingId);
+        if (Objects.isNull(responseDto))
+            return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, true));
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
+
+    @PostMapping()
+    public ResponseEntity<BaseResponse<?>> createParticipation(@UserId final Long userId,
+                                                               @RequestBody final ParticipationReqeustDto requestDto) {
+        final ParticipationResponseDto responseDto = participationService.createParticipation(userId, requestDto);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationController.java
@@ -22,7 +22,7 @@ public class ParticipationController {
     private final AuthService authService;
     private final ParticipationService participationService;
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<BaseResponse<?>> findMeetingAvailability(@UserId final Long userId,
                                                                    @RequestParam final Long meetingId) {
         final ParticipationAvailabilityResponseDto responseDto = participationService.findParticipationAvailability(userId, meetingId);
@@ -31,7 +31,7 @@ public class ParticipationController {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<BaseResponse<?>> createParticipation(@UserId final Long userId,
                                                                @RequestBody final ParticipationReqeustDto requestDto) {
         final ParticipationResponseDto responseDto = participationService.createParticipation(userId, requestDto);

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -30,4 +30,13 @@ public class Meeting extends BaseTimeEntity {
     private String memo;
     @Enumerated(value = EnumType.STRING)
     private MeetingStatus meetingStatus;
+
+    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDate date, LocalTime time, String memo){
+        this.title = (title != null) ? title : this.title;
+        this.place = (place != null) ? place : this.place;
+        this.date = (date != null) ? date : this.date;
+        this.time = (time != null) ? time : this.time;
+        this.memo = (memo != null) ? memo : this.place;
+
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -31,7 +31,7 @@ public class Meeting extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private MeetingStatus meetingStatus;
 
-    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDate date, LocalTime time, String memo){
+    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDate date, LocalTime time, String memo) {
         this.title = (title != null) ? title : this.title;
         this.place = (place != null) ? place : this.place;
         this.date = (date != null) ? date : this.date;

--- a/src/main/java/org/baggle/domain/meeting/dto/reponse/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/reponse/ParticipationDetailResponseDto.java
@@ -8,6 +8,7 @@ import org.baggle.domain.meeting.domain.MeetingAuthority;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.user.domain.User;
 
+import java.util.List;
 import java.util.Objects;
 
 @Getter
@@ -40,5 +41,15 @@ public class ParticipationDetailResponseDto {
                 .buttonAuthority(participation.getButtonAuthority())
                 .feed(feed)
                 .build();
+    }
+
+    public static List<ParticipationDetailResponseDto> listOf(List<Participation> participations) {
+        return participations.stream()
+                .map(participation ->
+                        ParticipationDetailResponseDto.of(
+                                participation,
+                                participation.getUser(),
+                                participation.getFeed()))
+                .toList();
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/dto/reponse/UpdateMeetingInfoResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/reponse/UpdateMeetingInfoResponseDto.java
@@ -15,7 +15,8 @@ public class UpdateMeetingInfoResponseDto {
     private LocalDate date;
     private LocalTime time;
     private String memo;
-    public static UpdateMeetingInfoResponseDto of(Long meetingId, String title, String place, LocalDate date, LocalTime time, String memo){
+
+    public static UpdateMeetingInfoResponseDto of(Long meetingId, String title, String place, LocalDate date, LocalTime time, String memo) {
         return UpdateMeetingInfoResponseDto.builder()
                 .meetingId(meetingId)
                 .title(title)

--- a/src/main/java/org/baggle/domain/meeting/dto/reponse/UpdateMeetingInfoResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/reponse/UpdateMeetingInfoResponseDto.java
@@ -1,0 +1,28 @@
+package org.baggle.domain.meeting.dto.reponse;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+@Getter
+public class UpdateMeetingInfoResponseDto {
+    private Long meetingId;
+    private String title;
+    private String place;
+    private LocalDate date;
+    private LocalTime time;
+    private String memo;
+    public static UpdateMeetingInfoResponseDto of(Long meetingId, String title, String place, LocalDate date, LocalTime time, String memo){
+        return UpdateMeetingInfoResponseDto.builder()
+                .meetingId(meetingId)
+                .title(title)
+                .place(place)
+                .date(date)
+                .time(time)
+                .memo(memo)
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
@@ -2,8 +2,6 @@ package org.baggle.domain.meeting.dto.request;
 
 
 import lombok.Getter;
-import org.baggle.domain.meeting.domain.*;
-import org.baggle.domain.user.domain.User;
 
 @Getter
 public class ParticipationReqeustDto {

--- a/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationReqeustDto.java
@@ -1,8 +1,11 @@
 package org.baggle.domain.meeting.dto.request;
 
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ParticipationReqeustDto {
     private Long meetingId;

--- a/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
@@ -1,10 +1,12 @@
 package org.baggle.domain.meeting.dto.request;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class UpdateMeetingInfoRequestDto {
     private Long meetingId;

--- a/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
@@ -3,9 +3,9 @@ package org.baggle.domain.meeting.dto.request;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class UpdateMeetingInfoRequestDto {

--- a/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
@@ -1,0 +1,16 @@
+package org.baggle.domain.meeting.dto.request;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class UpdateMeetingInfoRequestDto {
+    private Long meetingId;
+    private String title;
+    private String place;
+    private LocalDate date;
+    private LocalTime time;
+    private String memo;
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.meeting.dto.reponse;
+package org.baggle.domain.meeting.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationAvailabilityResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationAvailabilityResponseDto.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.meeting.dto.reponse;
+package org.baggle.domain.meeting.dto.response;
 
 
 import lombok.Builder;

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.meeting.dto.reponse;
+package org.baggle.domain.meeting.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationResponseDto.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.meeting.dto.reponse;
+package org.baggle.domain.meeting.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/baggle/domain/meeting/dto/response/UpdateMeetingInfoResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/UpdateMeetingInfoResponseDto.java
@@ -1,4 +1,4 @@
-package org.baggle.domain.meeting.dto.reponse;
+package org.baggle.domain.meeting.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -13,4 +14,10 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Query("SELECT m FROM Meeting m WHERE " +
             "m.date = :currentDate AND m.time between :prevTime and :currentTime ")
     List<Meeting> findMeetingsStartingSoon(@Param(value = "prevTime") LocalTime prevTime, @Param(value = "currentDate") LocalDate currentDate, @Param(value = "currentTime") LocalTime currentTime);
+
+    @Query("SELECT m FROM Meeting m " +
+            "JOIN Participation p ON m = p.meeting " +
+            "WHERE STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to " +
+            "AND p.user.id = :userId")
+    List<Meeting> findMeetingsWithinTimeRange(@Param("userId") Long userId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
     @Query("SELECT fcm.user.fcmToken FROM Participation p " +
@@ -17,5 +18,5 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             "WHERE p.buttonAuthority = :buttonAuthority AND m = :meeting")
     List<FcmToken> findFcmTokensByMeetingAndButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority);
 
-    Participation findFirstByUserIdAndMeetingId(Long userId, Long meetingId);
+    Optional<Participation> findByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
@@ -16,4 +16,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
             "JOIN u.fcmToken fcm " +
             "WHERE p.buttonAuthority = :buttonAuthority AND m = :meeting")
     List<FcmToken> findFcmTokensByMeetingAndButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority);
+
+    Participation findFirstByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -157,6 +157,6 @@ public class MeetingService {
 
     private FcmTimer getFcmTimer(Long fcmTimerId) {
         return fcmTimerRepository.findById(fcmTimerId)
-                .orElse(FcmTimer.getFcmTimerWithNull());
+                .orElse(FcmTimer.createFcmTimerWithNull());
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -4,22 +4,28 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmTimer;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.MeetingAuthority;
+import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.dto.reponse.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.reponse.ParticipationDetailResponseDto;
+import org.baggle.domain.meeting.dto.reponse.UpdateMeetingInfoResponseDto;
+import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.global.error.exception.EntityNotFoundException;
+import org.baggle.global.error.exception.ForbiddenException;
 import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
-import static org.baggle.global.error.exception.ErrorCode.INVALID_MEETING_PARTICIPATION;
-import static org.baggle.global.error.exception.ErrorCode.MEETING_NOT_FOUND;
+import static org.baggle.global.error.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -28,7 +34,6 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final ParticipationRepository participationRepository;
     private final FcmTimerRepository fcmTimerRepository;
-
 
     /**
      * throw 모임이 존재하지 않는 경우
@@ -44,12 +49,39 @@ public class MeetingService {
         return MeetingDetailResponseDto.of(meeting, certificationTime.getStartTime(), participationDetails);
     }
 
+    /**
+     * throw: 방장이 아닌 경우
+     * throw: 날짜 & 시간 수정 -> 모임 참가 인원중 2시간 이내 만남이 있는 경우
+     * throw: 날짜 & 시간 수정 -> 모임 시작이 2시간 이내일 경우.
+     * throw: 모임이 확정된 경우.
+     */
+    public UpdateMeetingInfoResponseDto updateMeetingInfo(Long userId, UpdateMeetingInfoRequestDto requestDto) {
+        Meeting meeting = meetingRepository.findById(requestDto.getMeetingId())
+                .orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
+
+        if (validateMeetingHost(meeting.getId(), userId))
+            throw new ForbiddenException(INVALID_MEETING_AUTHORITY);
+        if (meeting.getMeetingStatus() != MeetingStatus.SCHEDULED)
+            throw new ForbiddenException(INVALID_MODIFY_TIME);
+
+        if (requestDto.getDate() != null || requestDto.getTime() != null) {
+            LocalDate date = (requestDto.getDate() == null) ? meeting.getDate() : requestDto.getDate();
+            LocalTime time = (requestDto.getTime() == null) ? meeting.getTime() : requestDto.getTime();
+
+            if (getTimeUntilMeeting(meeting) <= 7200)
+                throw new ForbiddenException(INVALID_MODIFY_TIME);
+            if (!validateMeetingTime(meeting, date, time))
+                throw new InvalidValueException(UNAVAILABLE_MEETING_TIME);
+        }
+
+        meeting.updateTitleAndPlaceAndDateAndTimeAndMemo(requestDto.getTitle(), requestDto.getPlace(), requestDto.getDate(), requestDto.getTime(), requestDto.getMemo());
+        return UpdateMeetingInfoResponseDto.of(meeting.getId(), meeting.getTitle(), meeting.getPlace(), meeting.getDate(), meeting.getTime(), meeting.getMemo());
+    }
 
     /**
      * 서버 시간 기준 a ~ b분 사이에 모임을 조회하는 메서드입니다.
      * using:
      * NotificationScheduler - 1시간 전 모임 조회
-     * ParticipationService - 모임 전 후 2시간이내 모임 체크
      */
     public List<Meeting> findMeetingsInRange(LocalDateTime localDateTime, int from, int to) {
         LocalDateTime fromDateTime = localDateTime.plusMinutes(from);
@@ -61,25 +93,34 @@ public class MeetingService {
                 toDateTime.toLocalTime());
     }
 
+    private List<Meeting> findMeetingsInRangeForUser(Long userId, LocalDateTime localDateTime, int from, int to) {
+        LocalDateTime fromDateTime = localDateTime.plusMinutes(from);
+        LocalDateTime toDateTime = localDateTime.plusMinutes(to);
+
+        return meetingRepository.findMeetingsWithinTimeRange(
+                userId,
+                fromDateTime,
+                toDateTime);
+    }
+
     /**
      * 2시간 전,후 모임 여부를 확인하는 메서드
      * return: 모임이 있을 경우 True, else False
      */
-    public Boolean isMeetingInDeadline(Meeting meeting) {
+    public Boolean isMeetingInDeadline(Long userId, Meeting meeting) {
         LocalDateTime criteriaTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
-        List<Meeting> meetings = this.findMeetingsInRange(criteriaTime, -120, 120);
+        List<Meeting> meetings = this.findMeetingsInRangeForUser(userId, criteriaTime, -120, 120);
         return meetings.size() != 0;
     }
 
     /**
      * 모임 시간까지 남은 시간을 확인하는 메서드
-     * return: 1시간 이상 True, else False
      */
-    public Boolean isValidTime(Meeting meeting) {
+    public Long getTimeUntilMeeting(Meeting meeting) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
         Duration duration = Duration.between(now, meetingTime);
-        return duration.toSeconds() > 3600;
+        return duration.toSeconds();
     }
 
     private Boolean validateParticition(Meeting meeting, Long userId) {
@@ -87,4 +128,26 @@ public class MeetingService {
                 .stream()
                 .anyMatch(participation -> participation.getUser().getId() == userId);
     }
+
+    private Boolean validateMeetingHost(Long meetingId, Long userId) {
+        Participation participation = participationRepository.findFirstByUserIdAndMeetingId(userId, meetingId);
+        return participation.getMeetingAuthority() != MeetingAuthority.HOST;
+    }
+
+    private Boolean validateMeetingTime(Meeting meeting, LocalDate date, LocalTime time) {
+        LocalDateTime meetingTime = LocalDateTime.of(date, time);
+        for (Participation participation : meeting.getParticipations()) {
+            List<Meeting> meetings = findMeetingsInRangeForUser(participation.getUser().getId(), meetingTime, -120, 120)
+                    .stream()
+                    .filter(m -> m.getId() != meeting.getId())
+                    .toList();
+            System.out.println(meetings.size());
+            System.out.println(meetings.isEmpty());
+            if (!meetings.isEmpty())
+                return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -116,7 +116,7 @@ public class MeetingService {
     /**
      * 모임 시간까지 남은 시간을 확인하는 메서드
      */
-    public Long getTimeUntilMeeting(Meeting meeting) {
+    private Long getTimeUntilMeeting(Meeting meeting) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
         Duration duration = Duration.between(now, meetingTime);
@@ -141,8 +141,6 @@ public class MeetingService {
                     .stream()
                     .filter(m -> m.getId() != meeting.getId())
                     .toList();
-            System.out.println(meetings.size());
-            System.out.println(meetings.isEmpty());
             if (!meetings.isEmpty())
                 return Boolean.FALSE;
         }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -2,8 +2,8 @@ package org.baggle.domain.meeting.service;
 
 import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.domain.*;
-import org.baggle.domain.meeting.dto.reponse.ParticipationAvailabilityResponseDto;
-import org.baggle.domain.meeting.dto.reponse.ParticipationResponseDto;
+import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseDto;
+import org.baggle.domain.meeting.dto.response.ParticipationResponseDto;
 import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -48,8 +48,8 @@ public class ParticipationService {
      */
     public ParticipationResponseDto createParticipation(Long userId, ParticipationReqeustDto reqeustDto) {
         Meeting meeting = meetingRepository.findById(reqeustDto.getMeetingId()).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
-        if (!meetingService.isMeetingInDeadline(meeting) || !meetingService.isValidTime(meeting))
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        if (!meetingService.isMeetingInDeadline(userId, meeting) || meeting.getMeetingStatus() != MeetingStatus.SCHEDULED)
             throw new InvalidValueException(INVALID_MEETING_TIME);
         if (duplicateParticipation(meeting.getParticipations(), userId))
             throw new InvalidValueException(DUPLICATE_PARTICIPATION);

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -20,6 +20,8 @@ public enum ErrorCode {
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
     INVALID_MEETING_CAPACITY(HttpStatus.BAD_REQUEST, "모임 인원이 초과됐습니다."),
+    UNAVAILABLE_MEETING_TIME(HttpStatus.BAD_REQUEST, "해당 시간에 모임이 존재하는 참가자가 있습니다."),
+
 
     /**
      * 401 Unauthorized
@@ -43,6 +45,8 @@ public enum ErrorCode {
      * 403 Forbidden
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, "리소스 접근 권한이 없습니다."),
+    INVALID_MEETING_AUTHORITY(HttpStatus.FORBIDDEN, "올바른 미팅 권한자가 아닙니다."),
+    INVALID_MODIFY_TIME(HttpStatus.FORBIDDEN, "모임 정보 수정 가능한 시간이 아닙니다."),
 
     /**
      * 404 Not Found


### PR DESCRIPTION
## Related Issue 🍃

close #50 

## Description 🌴
- 1순위 api를 배포하였습니다.
- 모임 정보를 수정하는 api를 구현했습니다.
- 아래 사항에 예외 처리를 진행하였습니다.
  - 방장이 아닌 경우.
  - 모임 수정 시간이 지난 경우.
  - 참가자 인원 중 수정된 시간에 모임이 존재하는 경우.
- 모임 상태 여부를 확인 예외처리 로직을 수정했습니다.
