### PR TITLE
[feat] 카카오 OAuth Provider 구현

### DIFF
--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessToken.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessToken.java
@@ -1,0 +1,17 @@
+package org.baggle.domain.user.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KakaoAccessToken {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    public String getAccessTokenWithTokenType() {
+        return "Bearer " + accessToken;
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenFeignClient.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenFeignClient.java
@@ -1,0 +1,10 @@
+package org.baggle.domain.user.auth.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "kakao-access-token-feign-client", url = "https://kauth.kakao.com/oauth/token")
+public interface KakaoAccessTokenFeignClient {
+    @PostMapping(consumes = "application/x-www-form-urlencoded")
+    KakaoAccessToken getKakaoAccessToken(KakaoAccessTokenRequestDto kakaoAccessTokenRequestDto);
+}

--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenInfo.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenInfo.java
@@ -1,0 +1,11 @@
+package org.baggle.domain.user.auth.kakao;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class KakaoAccessTokenInfo {
+    private Long id;
+}

--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenInfoFeignClient.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenInfoFeignClient.java
@@ -1,0 +1,11 @@
+package org.baggle.domain.user.auth.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-access-token-info-feign-client", url = "https://kapi.kakao.com/v1/user/access_token_info")
+public interface KakaoAccessTokenInfoFeignClient {
+    @GetMapping
+    KakaoAccessTokenInfo getKakaoAccessTokenInfo(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenRequestDto.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoAccessTokenRequestDto.java
@@ -1,0 +1,31 @@
+package org.baggle.domain.user.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class KakaoAccessTokenRequestDto {
+    @JsonProperty("grant_type")
+    private String grantType;
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("redirect_uri")
+    private String redirectUri;
+    private String code;
+    @JsonProperty("client_secret")
+    private String clientSecret;
+
+    public static KakaoAccessTokenRequestDto of(String clientId, String redirectUri, String code, String clientSecret) {
+        return KakaoAccessTokenRequestDto.builder()
+                .grantType("authorization_code")
+                .clientId(clientId)
+                .redirectUri(redirectUri)
+                .code(code)
+                .clientSecret(clientSecret)
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/domain/user/auth/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/org/baggle/domain/user/auth/kakao/KakaoOAuthProvider.java
@@ -1,0 +1,37 @@
+package org.baggle.domain.user.auth.kakao;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.UnauthorizedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class KakaoOAuthProvider {
+    @Value("${oauth.kakao.client-id")
+    private String clientId;
+    @Value("${oauth.kakao.client-secret")
+    private String clientSecret;
+    @Value("${oauth.kakao.redirect-uri")
+    private String redirectUri;
+    private final KakaoAccessTokenFeignClient kakaoAccessTokenFeignClient;
+    private final KakaoAccessTokenInfoFeignClient kakaoAccessTokenInfoFeignClient;
+
+    public String getKakaoPlatformId(String authorizationCode) {
+        KakaoAccessTokenRequestDto kakaoAccessTokenRequestDto = KakaoAccessTokenRequestDto.of(clientId, redirectUri, authorizationCode, clientSecret);
+        KakaoAccessToken kakaoAccessToken = getKakaoAccessToken(kakaoAccessTokenRequestDto);
+        String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
+        KakaoAccessTokenInfo kakaoAccessTokenInfo = kakaoAccessTokenInfoFeignClient.getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        return String.valueOf(kakaoAccessTokenInfo.getId());
+    }
+
+    private KakaoAccessToken getKakaoAccessToken(KakaoAccessTokenRequestDto kakaoAccessTokenRequestDto) {
+        try {
+            return kakaoAccessTokenFeignClient.getKakaoAccessToken(kakaoAccessTokenRequestDto);
+        } catch (FeignException e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_AUTHORIZATION_CODE);
+        }
+    }
+}

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
      * 401 Unauthorized
      */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
-    INVALID_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 액세스 토큰입니다."),
+    INVALID_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, "카카오 인가 코드의 형식이 올바르지 않습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰의 형식이 올바르지 않습니다. Bearer 타입을 확인해 주세요."),
     INVALID_ACCESS_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "액세스 토큰의 값이 올바르지 않습니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),


### PR DESCRIPTION
## Related Issue 🍃
close #52 

## Description 🌴
- 카카오 OAuth access token 발급 feign client를 구현하였습니다.
- 회원 아이디를 조회하기 위해 발급 받은 카카오 access token의 정보를 조회하는 feign client를 구현하였습니다.
- 최종적으로 회원 아이디 조회를 담당하는 카카오 OAuth Provider를 구현하였습니다.
