### PR TITLE
[fix] Meeting Detail response dto 날짜 중복 데이터 수정

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
@@ -13,33 +13,31 @@ public class MeetingDetailResponseDto {
     private Long meetingId;
     private String title;
     private String place;
-    private String date;
-    private String time;
     private String memo;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime meetingTime;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime certificationTime;
     private List<ParticipationDetailResponseDto> members;
 
     @Builder
-    public MeetingDetailResponseDto(Long meetingId, String title, String place, String date, String time, String memo, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> members) {
+    public MeetingDetailResponseDto(Long meetingId, String title, String place, String memo, LocalDateTime meetingTime, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> members) {
         this.meetingId = meetingId;
         this.title = title;
         this.place = place;
-        this.date = date;
-        this.time = time;
         this.memo = memo;
+        this.meetingTime = meetingTime;
         this.certificationTime = certificationTime;
         this.members = members;
     }
 
-    public static MeetingDetailResponseDto of(Meeting meeting, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> participationDetailResponseDto) {
+    public static MeetingDetailResponseDto of(Meeting meeting, LocalDateTime meetingTime, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> participationDetailResponseDto) {
         return MeetingDetailResponseDto.builder()
                 .meetingId(meeting.getId())
                 .title(meeting.getTitle())
                 .place(meeting.getPlace())
-                .date(meeting.getDate().toString())
-                .time(meeting.getTime().toString())
                 .memo(meeting.getMemo())
+                .meetingTime(meetingTime)
                 .certificationTime(certificationTime)
                 .members(participationDetailResponseDto)
                 .build();

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -7,10 +7,10 @@ import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.MeetingAuthority;
 import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.domain.Participation;
+import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.ParticipationDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
-import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.global.error.exception.EntityNotFoundException;
@@ -46,7 +46,8 @@ public class MeetingService {
         FcmTimer certificationTime = getFcmTimer(requestId);
         List<Participation> participations = meeting.getParticipations();
         List<ParticipationDetailResponseDto> participationDetails = ParticipationDetailResponseDto.listOf(participations);
-        return MeetingDetailResponseDto.of(meeting, certificationTime.getStartTime(), participationDetails);
+        LocalDateTime meetingTime = getMeetingTime(meeting.getDate(), meeting.getTime());
+        return MeetingDetailResponseDto.of(meeting, meetingTime, certificationTime.getStartTime(), participationDetails);
     }
 
     /**
@@ -67,6 +68,10 @@ public class MeetingService {
     private Meeting getMeeting(Long meetingId) {
         return meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
+    }
+
+    private LocalDateTime getMeetingTime(LocalDate date, LocalTime time) {
+        return LocalDateTime.of(date, time);
     }
 
     /**


### PR DESCRIPTION
## Related Issue 🍃

close #70 

## Description 🌴
- date와 time을 하나로 합쳐 meetingTime으로 통합했습니다.
