### PR TITLE
[feat] 모임 생성 API 구현

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -4,14 +4,13 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.baggle.domain.fcm.domain.FcmTimer;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationService;
 import org.baggle.domain.meeting.domain.ButtonAuthority;
 import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.MeetingStatus;
-import org.baggle.domain.meeting.service.MeetingService;
+import org.baggle.domain.meeting.service.MeetingDetailService;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -32,7 +31,7 @@ import java.util.List;
 @EnableAsync
 @RequiredArgsConstructor
 public class NotificationScheduler {
-    private final MeetingService meetingService;
+    private final MeetingDetailService meetingDetailService;
     private final FcmNotificationService fcmNotificationService;
     private final FcmTimerRepository fcmTimerRepository;
 
@@ -45,7 +44,7 @@ public class NotificationScheduler {
     @Scheduled(cron = "0 * * * * *")
     public void notificationScheduleTask() throws FirebaseMessagingException {
         LocalDateTime now = LocalDateTime.now();
-        List<Meeting> notificationMeeting = meetingService.findMeetingsInRange(now, 59, 60);
+        List<Meeting> notificationMeeting = meetingDetailService.findMeetingsInRange(now, 59, 60);
         for (Meeting m : notificationMeeting) {
             if (m.getMeetingStatus() != MeetingStatus.SCHEDULED) continue;
             m.updateMeetingStatusIntoConfirmation();

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
-import org.baggle.domain.meeting.service.MeetingService;
+import org.baggle.domain.meeting.service.MeetingDetailService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
@@ -16,20 +16,21 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/meeting")
 @Controller
 public class MeetingApiController {
-    private final MeetingService meetingService;
+    private final MeetingDetailService meetingDetailService;
 
     @GetMapping("/detail")
     public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId final Long userId,
                                                              @RequestParam final Long meetingId) {
-        MeetingDetailResponseDto responseDto = meetingService.findMeetingDetail(userId, meetingId);
+        MeetingDetailResponseDto responseDto = meetingDetailService.findMeetingDetail(userId, meetingId);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 
     @PatchMapping
     public ResponseEntity<BaseResponse<?>> updateMeetingInfo(@UserId final Long userId,
                                                              @RequestBody final UpdateMeetingInfoRequestDto requestDto) {
-        final UpdateMeetingInfoResponseDto responseDto = meetingService.updateMeetingInfo(userId, requestDto);
+        final UpdateMeetingInfoResponseDto responseDto = meetingDetailService.updateMeetingInfo(userId, requestDto);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
+
 
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
@@ -1,10 +1,12 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.dto.request.CreateMeetingRequestDto;
+import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
-import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.service.MeetingDetailService;
+import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
@@ -16,7 +18,15 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/meeting")
 @Controller
 public class MeetingApiController {
+    private final MeetingService meetingService;
     private final MeetingDetailService meetingDetailService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<?>> createMeeting(@UserId final Long userId,
+                                                         @RequestBody final CreateMeetingRequestDto createMeetingRequestDto) {
+        meetingService.createMeeting(userId, createMeetingRequestDto);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, true));
+    }
 
     @GetMapping("/detail")
     public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId final Long userId,
@@ -31,6 +41,4 @@ public class MeetingApiController {
         final UpdateMeetingInfoResponseDto responseDto = meetingDetailService.updateMeetingInfo(userId, requestDto);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
-
-
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
@@ -1,7 +1,7 @@
 package org.baggle.domain.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
+import org.baggle.domain.meeting.dto.request.ParticipationRequestDto;
 import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseDto;
 import org.baggle.domain.meeting.service.ParticipationService;
 import org.baggle.global.common.BaseResponse;
@@ -26,7 +26,7 @@ public class ParticipationApiController {
 
     @PostMapping("/participation")
     public ResponseEntity<BaseResponse<?>> createParticipation(@UserId final Long userId,
-                                                               @RequestBody final ParticipationReqeustDto requestDto) {
+                                                               @RequestBody final ParticipationRequestDto requestDto) {
         participationService.createParticipation(userId, requestDto);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, true));
     }

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -2,6 +2,7 @@ package org.baggle.domain.meeting.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.baggle.domain.user.domain.User;
 import org.baggle.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
@@ -19,7 +20,8 @@ public class Meeting extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "meeting_id")
     private Long id;
-    @OneToMany(mappedBy = "meeting")
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Participation> participations = new ArrayList<>();
     @Column(nullable = false)
     private String title;
@@ -31,6 +33,21 @@ public class Meeting extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private MeetingStatus meetingStatus;
 
+    public static Meeting createMeeting(User user, String title, String place, LocalDate date, LocalTime time, String memo) {
+        Meeting meeting = Meeting.builder()
+                .title(title)
+                .place(place)
+                .date(date)
+                .time(time)
+                .memo(memo)
+                .meetingStatus(MeetingStatus.SCHEDULED)
+                .build();
+        Participation participation = Participation.createParticipation();
+        participation.changeUser(user);
+        participation.changeMeeting(meeting);
+        return meeting;
+    }
+
     public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDate date, LocalTime time, String memo) {
         this.title = (title != null) ? title : this.title;
         this.place = (place != null) ? place : this.place;
@@ -39,13 +56,15 @@ public class Meeting extends BaseTimeEntity {
         this.memo = (memo != null) ? memo : this.place;
     }
 
-    public void updateMeetingStatusIntoConfirmation(){
+    public void updateMeetingStatusIntoConfirmation() {
         this.meetingStatus = MeetingStatus.CONFIRMATION;
     }
-    public void updateMeetingStatusIntoOngoing(){
+
+    public void updateMeetingStatusIntoOngoing() {
         this.meetingStatus = MeetingStatus.ONGOING;
     }
-    public void updateMeetingStatusIntoTermination(){
+
+    public void updateMeetingStatusIntoTermination() {
         this.meetingStatus = MeetingStatus.TERMINATION;
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -33,7 +33,15 @@ public class Participation extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private ButtonAuthority buttonAuthority;
 
-    public static Participation createParticipationWithoutFeed(User user, Meeting meeting, MeetingAuthority meetingAuthority, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority){
+    public static Participation createParticipation() {
+        return Participation.builder()
+                .meetingAuthority(MeetingAuthority.HOST)
+                .participationMeetingStatus(ParticipationMeetingStatus.PARTICIPATING)
+                .buttonAuthority(ButtonAuthority.NON_OWNER)
+                .build();
+    }
+
+    public static Participation createParticipationWithoutFeed(User user, Meeting meeting, MeetingAuthority meetingAuthority, ParticipationMeetingStatus participationMeetingStatus, ButtonAuthority buttonAuthority) {
         return Participation.builder()
                 .user(user)
                 .meeting(meeting)
@@ -43,4 +51,13 @@ public class Participation extends BaseTimeEntity {
                 .build();
     }
 
+    public void changeUser(User user) {
+        this.user = user;
+        user.getParticipations().add(this);
+    }
+
+    public void changeMeeting(Meeting meeting) {
+        this.meeting = meeting;
+        meeting.getParticipations().add(this);
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/dto/request/CreateMeetingRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/CreateMeetingRequestDto.java
@@ -1,0 +1,18 @@
+package org.baggle.domain.meeting.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CreateMeetingRequestDto {
+    private String title;
+    private String place;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime meetingTime;
+    private String memo;
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/ParticipationRequestDto.java
@@ -7,6 +7,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ParticipationReqeustDto {
+public class ParticipationRequestDto {
     private Long meetingId;
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -20,4 +20,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "WHERE STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to " +
             "AND p.user.id = :userId")
     List<Meeting> findMeetingsWithinTimeRange(@Param("userId") Long userId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+
+    @Query("SELECT count(m) FROM Meeting m " +
+            "JOIN Participation p on m = p.meeting " +
+            "WHERE m.date = :date AND p.user.id = :userId")
+    Long countMeetingWithinDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -42,7 +42,7 @@ public class MeetingDetailService {
      */
     public MeetingDetailResponseDto findMeetingDetail(Long userId, Long requestId) {
         Meeting meeting = getMeeting(requestId);
-        validateParticition(meeting, userId);
+        validateParticipation(meeting, userId);
         FcmTimer certificationTime = getFcmTimer(requestId);
         List<Participation> participations = meeting.getParticipations();
         List<ParticipationDetailResponseDto> participationDetails = ParticipationDetailResponseDto.listOf(participations);
@@ -104,10 +104,10 @@ public class MeetingDetailService {
         return duration.toSeconds();
     }
 
-    private void validateParticition(Meeting meeting, Long userId) {
-        boolean isvalidParticipation = meeting.getParticipations().stream()
+    private void validateParticipation(Meeting meeting, Long userId) {
+        boolean isValidParticipation = meeting.getParticipations().stream()
                 .anyMatch(participation -> participation.getUser().getId() == userId);
-        if (!isvalidParticipation)
+        if (!isValidParticipation)
             throw new InvalidValueException(INVALID_MEETING_PARTICIPATION);
     }
 

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -31,7 +31,7 @@ import static org.baggle.global.error.exception.ErrorCode.*;
 @RequiredArgsConstructor
 @Transactional
 @Service
-public class MeetingService {
+public class MeetingDetailService {
     private final MeetingRepository meetingRepository;
     private final ParticipationRepository participationRepository;
     private final FcmTimerRepository fcmTimerRepository;

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -1,0 +1,76 @@
+package org.baggle.domain.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.dto.request.CreateMeetingRequestDto;
+import org.baggle.domain.meeting.repository.MeetingRepository;
+import org.baggle.domain.user.domain.User;
+import org.baggle.domain.user.repository.UserRepository;
+import org.baggle.global.error.exception.EntityNotFoundException;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.ForbiddenException;
+import org.baggle.global.error.exception.InvalidValueException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MeetingService {
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+
+    public void createMeeting(Long userId, CreateMeetingRequestDto createMeetingRequestDto) {
+        User findUser = getUser(userId);
+        validateCreateMeeting(findUser.getId(), createMeetingRequestDto.getMeetingTime());
+        Meeting meeting = createMeetingAndParticipationWithUser(findUser, createMeetingRequestDto);
+        meetingRepository.save(meeting);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateCreateMeeting(Long userId, LocalDateTime meetingTime) {
+        validateAvailableMeetingTime(userId, meetingTime);
+        LocalDate meetingDate = convertLocalDateTimeToLocalDate(meetingTime);
+        validateMaximumCreatableMeetings(userId, meetingDate);
+    }
+
+    private Meeting createMeetingAndParticipationWithUser(User user, CreateMeetingRequestDto createMeetingRequestDto) {
+        return Meeting.createMeeting(user, createMeetingRequestDto.getTitle(), createMeetingRequestDto.getPlace(),
+                convertLocalDateTimeToLocalDate(createMeetingRequestDto.getMeetingTime()),
+                convertLocalDateTimeToLocalTime(createMeetingRequestDto.getMeetingTime()),
+                createMeetingRequestDto.getMemo());
+    }
+
+    private void validateAvailableMeetingTime(Long userId, LocalDateTime meetingTime) {
+        LocalDateTime prevMeetingTime = meetingTime.minusHours(2L);
+        LocalDateTime nextMeetingTime = meetingTime.plusHours(2L);
+        List<Meeting> findMeetings = meetingRepository.findMeetingsWithinTimeRange(userId, prevMeetingTime, nextMeetingTime);
+        if (!findMeetings.isEmpty()) {
+            throw new InvalidValueException(ErrorCode.UNAVAILABLE_MEETING_TIME);
+        }
+    }
+
+    private void validateMaximumCreatableMeetings(Long userId, LocalDate meetingDate) {
+        Long meetingCount = meetingRepository.countMeetingWithinDate(userId, meetingDate);
+        if (meetingCount > 1) {
+            throw new ForbiddenException(ErrorCode.INVALID_CREATE_MEETING);
+        }
+    }
+
+    private LocalDate convertLocalDateTimeToLocalDate(LocalDateTime meetingTime) {
+        return meetingTime.toLocalDate();
+    }
+
+    private LocalTime convertLocalDateTimeToLocalTime(LocalDateTime meetingTime) {
+        return meetingTime.toLocalTime();
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -2,7 +2,7 @@ package org.baggle.domain.meeting.service;
 
 import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.domain.*;
-import org.baggle.domain.meeting.dto.request.ParticipationReqeustDto;
+import org.baggle.domain.meeting.dto.request.ParticipationRequestDto;
 import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
@@ -25,10 +25,10 @@ import static org.baggle.global.error.exception.ErrorCode.*;
 @Transactional
 @Service
 public class ParticipationService {
-    private final MeetingRepository meetingRepository;
-    private final ParticipationRepository participationRepository;
     private final MeetingDetailService meetingDetailService;
     private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+    private final ParticipationRepository participationRepository;
 
     /**
      * 현재 모임에 참여 여부를 판단하는 메서드.
@@ -49,8 +49,8 @@ public class ParticipationService {
     /**
      * 모임 참여 메서드
      */
-    public void createParticipation(Long userId, ParticipationReqeustDto reqeustDto) {
-        Meeting meeting = getMeeting(reqeustDto.getMeetingId());
+    public void createParticipation(Long userId, ParticipationRequestDto requestDto) {
+        Meeting meeting = getMeeting(requestDto.getMeetingId());
         User user = getUser(userId);
         Participation participation = Participation.createParticipationWithoutFeed(user, meeting, MeetingAuthority.PARTICIPATION, ParticipationMeetingStatus.PARTICIPATING, ButtonAuthority.NON_OWNER);
         validateMeetingStatus(meeting);
@@ -81,10 +81,10 @@ public class ParticipationService {
     }
 
     private void duplicateParticipation(List<Participation> participations, Long userId) {
-        boolean isDupilcate = participations.stream()
+        boolean isDuplicate = participations.stream()
                 .anyMatch(participation ->
                         Objects.equals(participation.getUser().getId(), userId));
-        if (isDupilcate)
+        if (isDuplicate)
             throw new ConflictException(DUPLICATE_PARTICIPATION);
     }
 
@@ -92,6 +92,4 @@ public class ParticipationService {
         if (meeting.getParticipations().size() == 6)
             throw new ForbiddenException(INVALID_MEETING_CAPACITY);
     }
-
-
 }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -27,7 +27,7 @@ import static org.baggle.global.error.exception.ErrorCode.*;
 public class ParticipationService {
     private final MeetingRepository meetingRepository;
     private final ParticipationRepository participationRepository;
-    private final MeetingService meetingService;
+    private final MeetingDetailService meetingDetailService;
     private final UserRepository userRepository;
 
     /**
@@ -77,7 +77,7 @@ public class ParticipationService {
 
     private void validateMeetingTime(Long userId, Meeting meeting) {
         LocalDateTime meetingTime = LocalDateTime.of(meeting.getDate(), meeting.getTime());
-        meetingService.isMeetingInDeadline(meeting.getId(), userId, meetingTime);
+        meetingDetailService.isMeetingInDeadline(meeting.getId(), userId, meetingTime);
     }
 
     private void duplicateParticipation(List<Participation> participations, Long userId) {

--- a/src/main/java/org/baggle/domain/user/domain/User.java
+++ b/src/main/java/org/baggle/domain/user/domain/User.java
@@ -23,6 +23,7 @@ public class User extends BaseTimeEntity {
     private String profileImageUrl;
     private String nickname;
     @OneToMany(mappedBy = "user")
+    @Builder.Default
     private List<Participation> participations = new ArrayList<>();
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private FcmToken fcmToken;

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     INVALID_MODIFY_TIME(HttpStatus.FORBIDDEN, "모임 정보 수정 가능한 시간이 아닙니다."),
     INVALID_MEETING_CAPACITY(HttpStatus.FORBIDDEN, "모임 인원이 초과됐습니다."),
     NOT_MATCH_BUTTON_OWNER(HttpStatus.FORBIDDEN, "긴급 버튼 할당자가 아닙니다."),
+    INVALID_CREATE_MEETING(HttpStatus.FORBIDDEN, "모임은 하루에 2개까지만 생성 가능합니다."),
 
     /**
      * 404 Not Found


### PR DESCRIPTION
## Related Issue 🍃
close #77

## Description 🌴
- 모임 생성 & 모임 조회 관련 비즈니스 로직을 구현하기 위해 기존 모임 상세 비즈니스 로직을 담당하는 서비스를 MeetingDetailService로 클래스명을 변경하였습니다. 따라서 모임 생성 & 모음 조회 관련 비즈니스 로직은 MeetingService가 담당하게 됩니다.
- 모임 생성 비즈니스 로직과 API를 구현하였습니다.
- 오타를 수정하였습니다.
