### PR TITLE
[feat] 전체 모임 조회 API 구현

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.dto.request.CreateMeetingRequestDto;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.dto.response.CreateMeetingResponseDto;
+import org.baggle.domain.meeting.dto.response.GetMeetingResponseDto;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
 import org.baggle.domain.meeting.service.MeetingDetailService;
@@ -11,6 +12,7 @@ import org.baggle.domain.meeting.service.MeetingService;
 import org.baggle.global.common.BaseResponse;
 import org.baggle.global.common.SuccessCode;
 import org.baggle.global.config.auth.UserId;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -29,10 +31,18 @@ public class MeetingApiController {
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.CREATED, createMeetingResponseDto));
     }
 
+    @GetMapping
+    public ResponseEntity<BaseResponse<?>> getMeetings(@UserId final Long userId,
+                                                       @RequestParam final String period,
+                                                       final Pageable pageable) {
+        final GetMeetingResponseDto getMeetingResponseDto = meetingService.getMeetings(userId, period, pageable);
+        return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, getMeetingResponseDto));
+    }
+
     @GetMapping("/detail")
     public ResponseEntity<BaseResponse<?>> findMeetingDetail(@UserId final Long userId,
                                                              @RequestParam final Long meetingId) {
-        MeetingDetailResponseDto responseDto = meetingDetailService.findMeetingDetail(userId, meetingId);
+        final MeetingDetailResponseDto responseDto = meetingDetailService.findMeetingDetail(userId, meetingId);
         return ResponseEntity.ok(BaseResponse.of(SuccessCode.OK, responseDto));
     }
 

--- a/src/main/java/org/baggle/domain/meeting/domain/Period.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Period.java
@@ -1,0 +1,24 @@
+package org.baggle.domain.meeting.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
+public enum Period {
+    SCHEDULED("scheduled"),
+    PAST("past");
+
+    private final String stringPeriod;
+
+    public static Period getEnumPeriodFromStringPeriod(String stringPeriod) {
+        return Arrays.stream(values())
+                .filter(period -> period.stringPeriod.equals(stringPeriod))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(ErrorCode.INVALID_PERIOD_TYPE));
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/response/GetMeetingResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/GetMeetingResponseDto.java
@@ -1,0 +1,26 @@
+package org.baggle.domain.meeting.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.baggle.domain.meeting.repository.MeetingCountQueryDto;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class GetMeetingResponseDto {
+    private Long scheduledCount;
+    private Long pastCount;
+    private List<MeetingResponseDto> meetings;
+
+    public static GetMeetingResponseDto of(MeetingCountQueryDto meetingCountQueryDto, List<MeetingResponseDto> meetings) {
+        return GetMeetingResponseDto.builder()
+                .scheduledCount(meetingCountQueryDto.getScheduledCount() != null ? meetingCountQueryDto.getScheduledCount() : 0)
+                .pastCount(meetingCountQueryDto.getPastCount() != null ? meetingCountQueryDto.getPastCount() : 0)
+                .meetings(meetings)
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/MeetingResponseDto.java
@@ -1,0 +1,50 @@
+package org.baggle.domain.meeting.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.Participation;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class MeetingResponseDto {
+    private int remainingDate;
+    private String title;
+    private String place;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime time;
+    private int participantCount;
+    private String status;
+    private List<ParticipantResponseDto> participants;
+
+    @Builder
+    private MeetingResponseDto(int remainingDate, String title, String place, LocalDateTime time, int participantCount, String status, List<Participation> participations) {
+        this.remainingDate = remainingDate;
+        this.title = title;
+        this.place = place;
+        this.time = time;
+        this.participantCount = participantCount;
+        this.status = status;
+        this.participants = participations.stream()
+                .map(participation -> ParticipantResponseDto.of(participation.getUser()))
+                .collect(Collectors.toList());
+    }
+
+    public static MeetingResponseDto of(Meeting meeting) {
+        return MeetingResponseDto.builder()
+                .remainingDate(Period.between(LocalDate.now(), meeting.getDate()).getDays())
+                .title(meeting.getTitle())
+                .place(meeting.getTitle())
+                .time(LocalDateTime.of(meeting.getDate(), meeting.getTime()))
+                .participantCount(meeting.getParticipations().size())
+                .status(meeting.getMeetingStatus().name())
+                .participations(meeting.getParticipations())
+                .build();
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/dto/response/MeetingResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/MeetingResponseDto.java
@@ -40,7 +40,7 @@ public class MeetingResponseDto {
         return MeetingResponseDto.builder()
                 .remainingDate(Period.between(LocalDate.now(), meeting.getDate()).getDays())
                 .title(meeting.getTitle())
-                .place(meeting.getTitle())
+                .place(meeting.getPlace())
                 .time(LocalDateTime.of(meeting.getDate(), meeting.getTime()))
                 .participantCount(meeting.getParticipations().size())
                 .status(meeting.getMeetingStatus().name())

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipantResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipantResponseDto.java
@@ -1,0 +1,16 @@
+package org.baggle.domain.meeting.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.baggle.domain.user.domain.User;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ParticipantResponseDto {
+    private String profileImageUrl;
+
+    public static ParticipantResponseDto of(User user) {
+        return new ParticipantResponseDto(user.getProfileImageUrl());
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingCountQueryDto.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingCountQueryDto.java
@@ -1,0 +1,11 @@
+package org.baggle.domain.meeting.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MeetingCountQueryDto {
+    private Long scheduledCount;
+    private Long pastCount;
+}

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -1,6 +1,9 @@
 package org.baggle.domain.meeting.repository;
 
 import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.MeetingStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,20 +12,53 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
-    @Query("SELECT m FROM Meeting m WHERE " +
-            "m.date = :currentDate AND m.time between :prevTime and :currentTime ")
+    @Query("SELECT m " +
+            "FROM Meeting m " +
+            "WHERE m.date = :currentDate " +
+            "AND m.time BETWEEN :prevTime AND :currentTime ")
     List<Meeting> findMeetingsStartingSoon(@Param(value = "prevTime") LocalTime prevTime, @Param(value = "currentDate") LocalDate currentDate, @Param(value = "currentTime") LocalTime currentTime);
 
-    @Query("SELECT m FROM Meeting m " +
-            "JOIN Participation p ON m = p.meeting " +
+    @Query("SELECT m " +
+            "FROM Meeting m " +
+            "JOIN Participation p " +
+            "ON m = p.meeting " +
             "WHERE STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to " +
             "AND p.user.id = :userId")
     List<Meeting> findMeetingsWithinTimeRange(@Param("userId") Long userId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 
-    @Query("SELECT count(m) FROM Meeting m " +
-            "JOIN Participation p on m = p.meeting " +
-            "WHERE m.date = :date AND p.user.id = :userId")
+    @Query("SELECT count(m) " +
+            "FROM Meeting m " +
+            "JOIN Participation p " +
+            "ON m = p.meeting " +
+            "WHERE m.date = :date " +
+            "AND p.user.id = :userId")
     Long countMeetingWithinDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    @Query("SELECT new org.baggle.domain.meeting.repository.MeetingCountQueryDto(SUM(CASE WHEN m.meetingStatus != :meetingStatus THEN 1 END), SUM(CASE WHEN m.meetingStatus = :meetingStatus THEN 1 END)) " +
+            "FROM Meeting m " +
+            "JOIN Participation p " +
+            "ON p.meeting = m " +
+            "WHERE p.user.id = :userId")
+    Optional<MeetingCountQueryDto> countMeetings(@Param("meetingStatus") MeetingStatus meetingStatus, @Param("userId") Long userId);
+
+    @Query("SELECT m " +
+            "FROM Meeting m " +
+            "JOIN FETCH m.participations p " +
+            "JOIN FETCH p.user u " +
+            "WHERE u.id = :userId " +
+            "AND m.meetingStatus = :meetingStatus " +
+            "ORDER BY TIMEDIFF(:currTime, STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'))")
+    Page<Meeting> findMeetingsWithMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);
+
+    @Query("SELECT m " +
+            "FROM Meeting m " +
+            "JOIN FETCH m.participations p " +
+            "JOIN FETCH p.user u " +
+            "WHERE u.id = :userId " +
+            "AND m.meetingStatus != :meetingStatus " +
+            "ORDER BY TIMEDIFF(STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'), :currTime)")
+    Page<Meeting> findMeetingsWithoutMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/ParticipationRepository.java
@@ -6,17 +6,20 @@ import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.Participation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ParticipationRepository extends JpaRepository<Participation, Long> {
-    @Query("SELECT fcm.user.fcmToken FROM Participation p " +
+    @Query("SELECT fcm.user.fcmToken " +
+            "FROM Participation p " +
             "JOIN p.meeting m " +
             "JOIN p.user u " +
             "JOIN u.fcmToken fcm " +
-            "WHERE p.buttonAuthority = :buttonAuthority AND m = :meeting")
-    List<FcmToken> findFcmTokensByMeetingAndButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority);
+            "WHERE p.buttonAuthority = :buttonAuthority " +
+            "AND m = :meeting")
+    List<FcmToken> findFcmTokensByMeetingAndButtonAuthority(@Param("meeting") Meeting meeting, @Param("buttonAuthority") ButtonAuthority buttonAuthority);
 
     Optional<Participation> findByUserIdAndMeetingId(Long userId, Long meetingId);
 }

--- a/src/main/java/org/baggle/global/config/MessageConfig.java
+++ b/src/main/java/org/baggle/global/config/MessageConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
+
 @Configuration
 public class MessageConfig {
     @Bean

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
     UNAVAILABLE_MEETING_TIME(HttpStatus.BAD_REQUEST, "모임 2시간 전후 일정이 존재합니다."),
+    INVALID_PERIOD_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 기간 타입입니다."),
 
     /**
      * 401 Unauthorized
@@ -58,6 +59,7 @@ public enum ErrorCode {
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 정보를 찾을 수 없습니다."),
     PARTICIPATION_NOT_FOUND(HttpStatus.NOT_FOUND, "모임 참가자를 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    MEETING_COUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "모임의 총개수를 확인할 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## Related Issue 🍃
close #85 

## Description 🌴
- 전체 모임 조회 API 비즈니스 로직을 구현하였습니다.
- 정렬 기준은 query 조회 시간과 비교하여 가장 가까운 모임이 먼저 조회되도록 설정하였습니다.
