### PR TITLE
[feat] p6spy 쿼리 로깅 라이브러리 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // aws
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
@@ -38,16 +34,16 @@ dependencies {
 
     // flyway
     implementation "org.flywaydb:flyway-core"
-
-    // flyway와 mysql 버전 8과 맞추기 위해 사용
     implementation "org.flywaydb:flyway-mysql"
 
     // h2
-    //runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.h2database:h2'
+
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.security:spring-security-test'
 
     // jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
@@ -59,6 +55,17 @@ dependencies {
 
     // open feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
+
+    // p6spy
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/baggle/global/config/CustomP6spySqlFormatter.java
+++ b/src/main/java/org/baggle/global/config/CustomP6spySqlFormatter.java
@@ -1,0 +1,31 @@
+package org.baggle.global.config;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@Component
+public class CustomP6spySqlFormatter implements MessageFormattingStrategy {
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        return String.format("[SQL] %s | %s | %d ms | %s ", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(LocalDateTime.now()), category, elapsed, formatSql(category, sql));
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+            String trimmedSql = sql.trim().toLowerCase(Locale.ROOT);
+            if (trimmedSql.startsWith("create") || trimmedSql.startsWith("alter") || trimmedSql.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            }
+            sql = FormatStyle.BASIC.getFormatter().format(sql);
+            return sql;
+        }
+        return sql;
+    }
+}

--- a/src/main/java/org/baggle/global/config/P6spyConfig.java
+++ b/src/main/java/org/baggle/global/config/P6spyConfig.java
@@ -1,0 +1,14 @@
+package org.baggle.global.config;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+public class P6spyConfig {
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(CustomP6spySqlFormatter.class.getName());
+    }
+}


### PR DESCRIPTION
## Related Issue 🍃
close #93 

## Description 🌴
- 테스트시 SQL의 가독성을 높이고 파라미터의 값을 확인하기 위해 쿼리 로깅 외부 라이브러리 p6spy를 추가하였습니다.
- Custom Formatter를 구현하여 SQL을 Multiline으로 Formatting하고 쿼리 시간과 파라미터 값을 확인할 수 있도록 설정하였습니다.

<img width="1076" alt="test" src="https://github.com/dnd-side-project/dnd-9th-2-backend/assets/81796317/34445585-234f-4cfd-8b40-20866e542b24">