### PR TITLE
[fix] 전체 모임 조회 API 페이징 오류 수정

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -46,18 +46,20 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     @Query("SELECT m " +
             "FROM Meeting m " +
-            "JOIN FETCH m.participations p " +
-            "JOIN FETCH p.user u " +
-            "WHERE u.id = :userId " +
+            "JOIN Participation p " +
+            "ON m = p.meeting " +
+            "JOIN User u " +
+            "ON u.id = :userId " +
             "AND m.meetingStatus = :meetingStatus " +
             "ORDER BY TIMEDIFF(:currTime, STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'))")
     Page<Meeting> findMeetingsWithMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);
 
     @Query("SELECT m " +
             "FROM Meeting m " +
-            "JOIN FETCH m.participations p " +
-            "JOIN FETCH p.user u " +
-            "WHERE u.id = :userId " +
+            "JOIN Participation p " +
+            "ON m = p.meeting " +
+            "JOIN User u " +
+            "ON u.id = :userId " +
             "AND m.meetingStatus != :meetingStatus " +
             "ORDER BY TIMEDIFF(STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'), :currTime)")
     Page<Meeting> findMeetingsWithoutMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);


### PR DESCRIPTION
## Related Issue 🍃
close #99 

## Description 🌴
- 전체 모임 조회에서 1:N 컬렉션 fetch join 후 페이징으로 데이터를 받아올 때, 데이터 중복으로 인해 발생한 페이징 오류를 컬렉션 fetch join 제거 후 batch fetch size를 적용하여 해결하였습니다.
