### PR TITLE
[feat] 방장 위임 후 모임 탈퇴 api 제작

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/ParticipationApiController.java
@@ -33,4 +33,12 @@ public class ParticipationApiController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.of(SuccessCode.CREATED, null));
     }
+
+    @PatchMapping("/delegate")
+    public ResponseEntity<BaseResponse<?>> delegateMeetingHost(@RequestParam final Long fromMemberId,
+                                                               @RequestParam final Long toMemberId) {
+        participationService.delegateMeetingHost(fromMemberId, toMemberId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.of(SuccessCode.OK, null));
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -20,6 +20,7 @@ public class Meeting extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "meeting_id")
     private Long id;
+    @Getter
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Participation> participations = new ArrayList<>();
@@ -78,5 +79,9 @@ public class Meeting extends BaseTimeEntity {
 
     public Participation getRandomNumberParticipation(int randomNumber) {
         return getParticipations().get(randomNumber);
+    }
+
+    public void withdrawParticipation(Participation participation) {
+        this.participations.remove(participation);
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -20,7 +20,6 @@ public class Meeting extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "meeting_id")
     private Long id;
-    @Getter
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Participation> participations = new ArrayList<>();

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -74,11 +74,4 @@ public class Participation extends BaseTimeEntity {
     public void updateMeetingAuthorityToParticipation() {
         this.meetingAuthority = MeetingAuthority.PARTICIPATION;
     }
-
-    public void withdraw() {
-        this.meetingAuthority = null;
-        this.buttonAuthority = null;
-        this.participationMeetingStatus = null;
-        this.meeting.withdrawParticipation(this);
-    }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -41,7 +41,7 @@ public class Participation extends BaseTimeEntity {
                 .build();
     }
 
-    public static Participation createParticipationWithoutFeed(User user, Meeting meeting) {
+    public static Participation createParticipationWithMeeting(User user, Meeting meeting) {
         Participation participation = Participation.builder()
                 .user(user)
                 .meeting(meeting)
@@ -49,7 +49,6 @@ public class Participation extends BaseTimeEntity {
                 .buttonAuthority(ButtonAuthority.NON_OWNER)
                 .meetingAuthority(MeetingAuthority.PARTICIPATION)
                 .build();
-        meeting.initButtonAuthorityOfParticipationList();
         meeting.addParticipation(participation);
         return participation;
     }
@@ -66,5 +65,20 @@ public class Participation extends BaseTimeEntity {
 
     public void updateButtonAuthority(ButtonAuthority buttonAuthority) {
         this.buttonAuthority = buttonAuthority;
+    }
+
+    public void updateMeetingAuthorityToHost() {
+        this.meetingAuthority = MeetingAuthority.HOST;
+    }
+
+    public void updateMeetingAuthorityToParticipation() {
+        this.meetingAuthority = MeetingAuthority.PARTICIPATION;
+    }
+
+    public void withdraw() {
+        this.meetingAuthority = null;
+        this.buttonAuthority = null;
+        this.participationMeetingStatus = null;
+        this.meeting.withdrawParticipation(this);
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -72,7 +72,7 @@ public class ParticipationService {
         validateMeetingHost(fromParticipation);
         validateMeetingStatus(meeting);
         delegateMeetingHostToOtherParticipation(fromParticipation, toParticipation);
-        withdrawBeforeMeetingConfirmation(fromParticipation);
+        withdrawBeforeMeetingConfirmation(fromParticipation, meeting);
         updateButtonAuthorityWithRandomNumber(meeting);
     }
 
@@ -105,8 +105,8 @@ public class ParticipationService {
         toParticipation.updateMeetingAuthorityToHost();
     }
 
-    private void withdrawBeforeMeetingConfirmation(Participation fromParticipation) {
-        fromParticipation.withdraw();
+    private void withdrawBeforeMeetingConfirmation(Participation fromParticipation, Meeting meeting) {
+        meeting.withdrawParticipation(fromParticipation);
         participationRepository.delete(fromParticipation);
     }
 

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -1,10 +1,7 @@
 package org.baggle.domain.meeting.service;
 
 import lombok.RequiredArgsConstructor;
-import org.baggle.domain.meeting.domain.ButtonAuthority;
-import org.baggle.domain.meeting.domain.Meeting;
-import org.baggle.domain.meeting.domain.MeetingStatus;
-import org.baggle.domain.meeting.domain.Participation;
+import org.baggle.domain.meeting.domain.*;
 import org.baggle.domain.meeting.dto.request.ParticipationRequestDto;
 import org.baggle.domain.meeting.dto.response.ParticipationAvailabilityResponseDto;
 import org.baggle.domain.meeting.repository.MeetingRepository;
@@ -64,6 +61,21 @@ public class ParticipationService {
         participationRepository.save(participation);
     }
 
+    /**
+     * throw: 방장이 아닌 경우
+     * throw: 방장 위임 가능 시간이 아닌 경우
+     */
+    public void delegateMeetingHost(Long fromMemberId, Long toMemberId) {
+        Participation fromParticipation = getParticipation(fromMemberId);
+        Participation toParticipation = getParticipation(toMemberId);
+        Meeting meeting = getMeetingWithParticipation(fromParticipation);
+        validateMeetingHost(fromParticipation);
+        validateMeetingStatus(meeting);
+        delegateMeetingHostToOtherParticipation(fromParticipation, toParticipation);
+        withdrawBeforeMeetingConfirmation(fromParticipation);
+        updateButtonAuthorityWithRandomNumber(meeting);
+    }
+
     private Meeting getMeeting(Long meetingId) {
         return meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new EntityNotFoundException(MEETING_NOT_FOUND));
@@ -72,6 +84,30 @@ public class ParticipationService {
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+    }
+
+    private Meeting getMeetingWithParticipation(Participation participation) {
+        return participation.getMeeting();
+    }
+
+    private Participation getParticipation(Long participationId) {
+        return participationRepository.findById(participationId)
+                .orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
+    }
+
+    private void validateMeetingHost(Participation participation) {
+        if (participation.getMeetingAuthority() != MeetingAuthority.HOST)
+            throw new ForbiddenException(INVALID_MEETING_AUTHORITY);
+    }
+
+    private void delegateMeetingHostToOtherParticipation(Participation fromParticipation, Participation toParticipation) {
+        fromParticipation.updateMeetingAuthorityToParticipation();
+        toParticipation.updateMeetingAuthorityToHost();
+    }
+
+    private void withdrawBeforeMeetingConfirmation(Participation fromParticipation) {
+        fromParticipation.withdraw();
+        participationRepository.delete(fromParticipation);
     }
 
     private void validateMeetingStatus(Meeting meeting) {
@@ -98,13 +134,14 @@ public class ParticipationService {
     }
 
     private Participation createParticipationWithRandomButtonAuthority(User user, Meeting meeting) {
-        Participation participation = Participation.createParticipationWithoutFeed(user, meeting);
+        Participation participation = Participation.createParticipationWithMeeting(user, meeting);
         updateButtonAuthorityWithRandomNumber(meeting);
         return participation;
     }
 
     private void updateButtonAuthorityWithRandomNumber(Meeting meeting) {
         int randomNumber = new Random().nextInt(meeting.getParticipations().size());
+        meeting.initButtonAuthorityOfParticipationList();
         Participation randomNumberParticipation = meeting.getRandomNumberParticipation(randomNumber);
         randomNumberParticipation.updateButtonAuthority(ButtonAuthority.OWNER);
     }


### PR DESCRIPTION
## Related Issue 🍃

close #105 

## Description 🌴
- 방장 위임 후 모임 탈퇴 api를 제작했습니다.
- 방장이 아닐 경우 & 모임 수정 시간이 아닐 경우 예외 처리를 했습니다.
- 만약 반장이 긴급 버튼의 소유자일 경우를 대비해 모임 탈퇴시 버튼 권한자를 랜덤으로 다시 설정합니다.
