### PR TITLE
[fix] 모임 생성자의 긴급 버튼 권한 수정

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -37,7 +37,7 @@ public class Participation extends BaseTimeEntity {
         return Participation.builder()
                 .meetingAuthority(MeetingAuthority.HOST)
                 .participationMeetingStatus(ParticipationMeetingStatus.PARTICIPATING)
-                .buttonAuthority(ButtonAuthority.NON_OWNER)
+                .buttonAuthority(ButtonAuthority.OWNER)
                 .build();
     }
 


### PR DESCRIPTION
## Related Issue 🍃
close #110 

## Description 🌴
- 모임 생성자의 긴급 버튼 권한을 NON_OWNER -> OWNER로 변경하였습니다.
