### PR TITLE
[fix] meeting status 추가

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -15,6 +15,7 @@ import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.service.MeetingDetailService;
 import org.springframework.context.MessageSource;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -32,24 +33,18 @@ import java.util.List;
 @Slf4j
 @Component
 @EnableAsync
+@EnableScheduling
 @RequiredArgsConstructor
 public class NotificationScheduler {
     private final MeetingDetailService meetingDetailService;
     private final FcmNotificationService fcmNotificationService;
     private final FcmNotificationProvider fcmNotificationProvider;
 
-    /**
-     * 시작 1시간 전 모임을 찾아 알람을 전송하는 메서드
-     * Cron 표현식을 사용한 작업 예약
-     * 초(0-59) 분(0-59) 시간(0-23) 일(1-31) 월(1-12) 요일(0-7)
-     */
     @Transactional
     @Scheduled(cron = "0 * * * * *")
     public void notificationScheduleTask() {
-        LocalDateTime now = LocalDateTime.now();
-        List<Meeting> notificationMeeting = meetingDetailService.findMeetingsInRange(now, 58, 60);
+        List<Meeting> notificationMeeting = meetingDetailService.findMeetingsInRange(59, 60, MeetingStatus.SCHEDULED);
         for (Meeting m : notificationMeeting) {
-            if (m.getMeetingStatus() != MeetingStatus.SCHEDULED) continue;
             m.updateMeetingStatusIntoConfirmation();
             sendNotificationByButtonAuthority(m, ButtonAuthority.OWNER);
             sendNotificationByButtonAuthority(m, ButtonAuthority.NON_OWNER);

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -53,30 +53,30 @@ public class NotificationScheduler {
         }
     }
 
-    private List<FcmToken> getFcmTokens(Meeting meeting, ButtonAuthority buttonAuthority){
+    private List<FcmToken> getFcmTokens(Meeting meeting, ButtonAuthority buttonAuthority) {
         return fcmNotificationService.findFcmTokensByButtonAuthority(meeting, buttonAuthority);
     }
 
-    private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting, ButtonAuthority buttonAuthority){
+    private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting, ButtonAuthority buttonAuthority) {
         List<FcmToken> fcmTokens = getFcmTokens(meeting, buttonAuthority);
         String title = getNotificationTitleWithButtonAuthority(buttonAuthority);
         String body = getNotificationBodyWithButtonAuthority(buttonAuthority);
         return FcmNotificationRequestDto.of(fcmTokens, title, body);
     }
 
-    private void sendNotificationByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority){
+    private void sendNotificationByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
         FcmNotificationRequestDto fcmNotificationRequestDto = createFcmNotificationRequestDto(meeting, buttonAuthority);
         fcmNotificationService.sendNotificationByToken(fcmNotificationRequestDto, meeting.getId());
     }
 
-    private String getNotificationTitleWithButtonAuthority(ButtonAuthority buttonAuthority){
-        if(buttonAuthority == ButtonAuthority.OWNER)
+    private String getNotificationTitleWithButtonAuthority(ButtonAuthority buttonAuthority) {
+        if (buttonAuthority == ButtonAuthority.OWNER)
             return fcmNotificationProvider.getButtonOwnerNotificationTitle();
         return fcmNotificationProvider.getConfirmationNotificationTitle();
     }
 
-    private String getNotificationBodyWithButtonAuthority(ButtonAuthority buttonAuthority){
-        if(buttonAuthority == ButtonAuthority.OWNER)
+    private String getNotificationBodyWithButtonAuthority(ButtonAuthority buttonAuthority) {
+        if (buttonAuthority == ButtonAuthority.OWNER)
             return fcmNotificationProvider.getButtonOwnerNotificationBody();
         return fcmNotificationProvider.getConfirmationNotificationBody();
     }

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -49,7 +49,7 @@ public class NotificationScheduler {
             sendNotificationByButtonAuthority(m, ButtonAuthority.OWNER);
             sendNotificationByButtonAuthority(m, ButtonAuthority.NON_OWNER);
             fcmNotificationService.createFcmNotification(m.getId());
-            log.info("meeting information - ID {}, date {}, time {}", m.getId(), m.getDate(), m.getTime());
+            log.info("meeting information - date {}, time {}", m.getDate(), m.getTime());
         }
     }
 

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -45,7 +45,7 @@ public class NotificationScheduler {
     public void notificationScheduleTask() {
         List<Meeting> notificationMeeting = meetingDetailService.findMeetingsInRange(59, 60, MeetingStatus.SCHEDULED);
         for (Meeting m : notificationMeeting) {
-            m.updateMeetingStatusIntoConfirmation();
+            m.updateMeetingStatusInto(MeetingStatus.CONFIRMATION);
             sendNotificationByButtonAuthority(m, ButtonAuthority.OWNER);
             sendNotificationByButtonAuthority(m, ButtonAuthority.NON_OWNER);
             fcmNotificationService.createFcmNotification(m.getId());

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
 import org.baggle.domain.fcm.repository.FcmRepository;
-import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationProvider;
 import org.baggle.domain.fcm.service.FcmNotificationService;
 import org.baggle.domain.feed.domain.Feed;
@@ -18,19 +17,16 @@ import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.domain.meeting.repository.ParticipationRepository;
-import org.baggle.domain.user.domain.User;
 import org.baggle.global.common.ImageType;
 import org.baggle.global.error.exception.ConflictException;
 import org.baggle.global.error.exception.EntityNotFoundException;
 import org.baggle.global.error.exception.ForbiddenException;
 import org.baggle.global.error.exception.InvalidValueException;
 import org.baggle.infra.s3.S3Provider;
-import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -89,15 +85,15 @@ public class FeedService {
                 .orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
     }
 
-    private FcmNotificationRequestDto createFcmNotificationRequestDto(Long meetingId){
+    private FcmNotificationRequestDto createFcmNotificationRequestDto(Long meetingId) {
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meetingId);
         String title = fcmNotificationProvider.getEmergencyNotificationTitle();
         String body = fcmNotificationProvider.getEmergencyNotificationBody();
         return FcmNotificationRequestDto.of(fcmTokens, title, body);
     }
 
-    private void validateButtonOwner(Participation participation){
-        if(participation.getButtonAuthority() != ButtonAuthority.OWNER)
+    private void validateButtonOwner(Participation participation) {
+        if (participation.getButtonAuthority() != ButtonAuthority.OWNER)
             throw new ForbiddenException(NOT_MATCH_BUTTON_OWNER);
     }
 

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -126,6 +126,6 @@ public class FeedService {
         fcmNotificationService.deleteFcmNotification(participation.getMeeting().getId());
         fcmNotificationService.createFcmTimer(participation.getMeeting().getId(), authorizationTime);
         Meeting meeting = getMeeting(participation.getMeeting().getId());
-        meeting.updateMeetingStatusIntoOngoing();
+        meeting.updateMeetingStatusInto(MeetingStatus.ONGOING);
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -55,17 +55,8 @@ public class Meeting extends BaseTimeEntity {
         this.time = (time != null) ? time : this.time;
         this.memo = (memo != null) ? memo : this.place;
     }
-
-    public void updateMeetingStatusIntoConfirmation() {
-        this.meetingStatus = MeetingStatus.CONFIRMATION;
-    }
-
-    public void updateMeetingStatusIntoOngoing() {
-        this.meetingStatus = MeetingStatus.ONGOING;
-    }
-
-    public void updateMeetingStatusIntoTermination() {
-        this.meetingStatus = MeetingStatus.TERMINATION;
+    public void updateMeetingStatusInto(MeetingStatus meetingStatus) {
+        this.meetingStatus = meetingStatus;
     }
 
     public void initButtonAuthorityOfParticipationList() {

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -55,6 +55,7 @@ public class Meeting extends BaseTimeEntity {
         this.time = (time != null) ? time : this.time;
         this.memo = (memo != null) ? memo : this.place;
     }
+
     public void updateMeetingStatusInto(MeetingStatus meetingStatus) {
         this.meetingStatus = meetingStatus;
     }

--- a/src/main/java/org/baggle/domain/meeting/domain/MeetingStatus.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/MeetingStatus.java
@@ -4,5 +4,6 @@ public enum MeetingStatus {
     SCHEDULED,
     CONFIRMATION,
     ONGOING,
-    TERMINATION
+    TERMINATION,
+    PAST;
 }

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -10,17 +10,10 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
-    @Query("SELECT m " +
-            "FROM Meeting m " +
-            "WHERE m.date = :currentDate " +
-            "AND m.time BETWEEN :prevTime AND :currentTime ")
-    List<Meeting> findMeetingsStartingSoon(@Param(value = "prevTime") LocalTime prevTime, @Param(value = "currentDate") LocalDate currentDate, @Param(value = "currentTime") LocalTime currentTime);
-
     @Query("SELECT m " +
             "FROM Meeting m " +
             "WHERE m.meetingStatus = :meetingStatus " +

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -23,6 +23,12 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     @Query("SELECT m " +
             "FROM Meeting m " +
+            "WHERE m.meetingStatus = :meetingStatus " +
+            "AND STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to ")
+    List<Meeting> findMeetingsWithinTimeRangeAlongMeetingStatus(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to, @Param("meetingStatus") MeetingStatus meetingStatus);
+
+    @Query("SELECT m " +
+            "FROM Meeting m " +
             "JOIN Participation p " +
             "ON m = p.meeting " +
             "WHERE STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to " +

--- a/src/main/java/org/baggle/domain/meeting/scheduler/MeetingScheduler.java
+++ b/src/main/java/org/baggle/domain/meeting/scheduler/MeetingScheduler.java
@@ -1,0 +1,37 @@
+package org.baggle.domain.meeting.scheduler;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.MeetingStatus;
+import org.baggle.domain.meeting.service.MeetingDetailService;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@EnableAsync
+@EnableScheduling
+public class MeetingScheduler {
+    private final MeetingDetailService meetingDetailService;
+
+    @Transactional
+    @Scheduled(cron = "30 * * * * *")
+    public void meetingScheduleTask(){
+        List<Meeting> meetingList = getMeetingList();
+        meetingList.forEach(meeting -> {
+            meeting.updateMeetingStatusInto(MeetingStatus.PAST);
+            log.info("Termination meeting information - date {}, time {}", meeting.getDate(), meeting.getTime());
+        });
+    }
+
+    private List<Meeting> getMeetingList(){
+        return meetingDetailService.findMeetingsInRange(-241, -240, MeetingStatus.TERMINATION);
+    }
+}

--- a/src/main/java/org/baggle/domain/meeting/scheduler/MeetingScheduler.java
+++ b/src/main/java/org/baggle/domain/meeting/scheduler/MeetingScheduler.java
@@ -23,15 +23,19 @@ public class MeetingScheduler {
 
     @Transactional
     @Scheduled(cron = "30 * * * * *")
-    public void meetingScheduleTask(){
+    public void meetingScheduleTask() {
         List<Meeting> meetingList = getMeetingList();
+        updateMeetingListStatus(meetingList);
+    }
+
+    private void updateMeetingListStatus(List<Meeting> meetingList) {
         meetingList.forEach(meeting -> {
             meeting.updateMeetingStatusInto(MeetingStatus.PAST);
             log.info("Termination meeting information - date {}, time {}", meeting.getDate(), meeting.getTime());
         });
     }
 
-    private List<Meeting> getMeetingList(){
+    private List<Meeting> getMeetingList() {
         return meetingDetailService.findMeetingsInRange(-241, -240, MeetingStatus.TERMINATION);
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -74,18 +74,14 @@ public class MeetingDetailService {
         return LocalDateTime.of(date, time);
     }
 
-    /**
-     * 서버 시간 기준 a ~ b분 사이에 모임을 조회하는 메서드입니다.
-     * using:
-     * NotificationScheduler - 1시간 전 모임 조회
-     */
-    public List<Meeting> findMeetingsInRange(LocalDateTime localDateTime, int from, int to) {
-        LocalDateTime fromDateTime = localDateTime.plusMinutes(from);
-        LocalDateTime toDateTime = localDateTime.plusMinutes(to);
-        return meetingRepository.findMeetingsStartingSoon(
-                fromDateTime.toLocalTime(),
-                toDateTime.toLocalDate(),
-                toDateTime.toLocalTime());
+    public List<Meeting> findMeetingsInRange(int from, int to, MeetingStatus meetingStatus) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime fromDateTime = now.plusMinutes(from);
+        LocalDateTime toDateTime = now.plusMinutes(to);
+        return meetingRepository.findMeetingsWithinTimeRangeAlongMeetingStatus(
+                fromDateTime,
+                toDateTime,
+                meetingStatus);
     }
 
     private List<Meeting> findMeetingsInRangeForUser(Long userId, LocalDateTime localDateTime, int from, int to) {

--- a/src/main/java/org/baggle/global/config/SchedulerConfig.java
+++ b/src/main/java/org/baggle/global/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package org.baggle.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    private final int POOL_SIZE = 2;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(POOL_SIZE); // 대기하는 스레드 개수
+        threadPoolTaskScheduler.setThreadNamePrefix("baggle-scheduled-task-"); // 스레드 이름
+        threadPoolTaskScheduler.initialize();
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/main/java/org/baggle/infra/redis/ExpirationListener.java
+++ b/src/main/java/org/baggle/infra/redis/ExpirationListener.java
@@ -54,7 +54,7 @@ public class ExpirationListener implements MessageListener {
         return fcmService.findFcmTokens(meetingId);
     }
 
-    private FcmNotificationRequestDto createFcmNotificationRequestDto(String dataType, Long meetingId){
+    private FcmNotificationRequestDto createFcmNotificationRequestDto(String dataType, Long meetingId) {
         List<FcmToken> fcmTokens = getFcmTokens(meetingId);
         String title = getNotificationTitle(dataType);
         String body = getNotificationBody(dataType);

--- a/src/main/java/org/baggle/infra/redis/ExpirationListener.java
+++ b/src/main/java/org/baggle/infra/redis/ExpirationListener.java
@@ -9,6 +9,7 @@ import org.baggle.domain.fcm.service.FcmNotificationProvider;
 import org.baggle.domain.fcm.service.FcmNotificationService;
 import org.baggle.domain.fcm.service.FcmService;
 import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.domain.MeetingStatus;
 import org.baggle.domain.meeting.repository.MeetingRepository;
 import org.baggle.global.error.exception.EntityNotFoundException;
 import org.baggle.global.error.exception.ErrorCode;
@@ -84,9 +85,9 @@ public class ExpirationListener implements MessageListener {
     private void updateMeetingStatus(Long meetingId, String dateType) {
         Meeting meeting = getMeeting(meetingId);
         if (getRedisDataType(dateType) == RedisDataType.FCM_NOTIFICATION)
-            meeting.updateMeetingStatusIntoOngoing();
+            meeting.updateMeetingStatusInto(MeetingStatus.ONGOING);
         else if (getRedisDataType(dateType) == RedisDataType.FCM_TIMER)
-            meeting.updateMeetingStatusIntoTermination();
+            meeting.updateMeetingStatusInto(MeetingStatus.TERMINATION);
     }
 
     private String getNotificationTitle(String dateType) {

--- a/src/main/resources/db/migration/V4__modify_meeting_status.sql
+++ b/src/main/resources/db/migration/V4__modify_meeting_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE meeting DROP CHECK meeting_chk_1;
+ALTER TABLE meeting ADD CHECK (meeting_status IN ('SCHEDULED', 'CONFIRMATION', 'ONGOING', 'TERMINATION', 'PAST'));

--- a/src/main/resources/db/migration/V4__modify_meeting_status_constraint.sql
+++ b/src/main/resources/db/migration/V4__modify_meeting_status_constraint.sql
@@ -1,1 +1,0 @@
-ALTER TABLE meeting MODIFY meeting_status VARCHAR(255) CHECK (meeting_status IN ('SCHEDULED', 'CONFIRMATION', 'ONGOING', 'TERMINATION', 'PAST'));

--- a/src/main/resources/db/migration/V4__modify_meeting_status_constraint.sql
+++ b/src/main/resources/db/migration/V4__modify_meeting_status_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE meeting MODIFY meeting_status VARCHAR(255) CHECK (meeting_status IN ('SCHEDULED', 'CONFIRMATION', 'ONGOING', 'TERMINATION', 'PAST'));


### PR DESCRIPTION
## Related Issue 🍃

close #107 

## Description 🌴
- meeting table의 constraint를 변경하였습니다.
- 종료된 모임을 찾기 위해 scheduler를 구현하였습니다.
- 다중 scheduler를 사용하기 위해 config를 만들어 Thread 사용 수를 증가시켰습니다. (+1)
- 기존에 모임 조회 쿼리 문을 meeting status와 함께 조회가능하도록 수정하였습니다.
- meeting status에 PAST를 추가하였습니다.
