### PR TITLE
[fix] 전체 모임 조회 API 변경 사항 적용

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -66,16 +66,16 @@ public class MeetingService {
     }
 
     private MeetingCountQueryDto getMeetingCount(Long userId) {
-        return meetingRepository.countMeetings(MeetingStatus.TERMINATION, userId)
+        return meetingRepository.countMeetings(MeetingStatus.PAST, userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEETING_COUNT_NOT_FOUND));
     }
 
     private List<MeetingResponseDto> getMeetingsAccordingToPeriod(Long userId, Period period, Pageable pageable) {
         Page<Meeting> meetings;
         if (period == Period.SCHEDULED) {
-            meetings = meetingRepository.findMeetingsWithoutMeetingStatus(userId, MeetingStatus.TERMINATION, LocalDateTime.now(), pageable);
+            meetings = meetingRepository.findMeetingsWithoutMeetingStatus(userId, MeetingStatus.PAST, LocalDateTime.now(), pageable);
         } else {
-            meetings = meetingRepository.findMeetingsWithMeetingStatus(userId, MeetingStatus.TERMINATION, LocalDateTime.now(), pageable);
+            meetings = meetingRepository.findMeetingsWithMeetingStatus(userId, MeetingStatus.PAST, LocalDateTime.now(), pageable);
         }
         return meetings.stream()
                 .map(MeetingResponseDto::of)


### PR DESCRIPTION
## Related Issue 🍃
close #113 

## Description 🌴
- 모임 상태 'PAST' 추가에 따른 변경 사항을 적용하였습니다.
- 'SCHEDULED', 'CONFIRMATION', 'ONGOING', 'TERMINATION'은 예정된 모임, 'PAST'는 지난 모임으로 조회되도록 변경하였습니다.
