### PR TITLE
[fix] 모임 정보 수정 api 응답 값 수정

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -6,6 +6,7 @@ import org.baggle.domain.user.domain.User;
 import org.baggle.global.common.BaseTimeEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,11 +49,11 @@ public class Meeting extends BaseTimeEntity {
         return meeting;
     }
 
-    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDate date, LocalTime time, String memo) {
+    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDateTime dateTime, String memo) {
         this.title = (title != null) ? title : this.title;
         this.place = (place != null) ? place : this.place;
-        this.date = (date != null) ? date : this.date;
-        this.time = (time != null) ? time : this.time;
+        this.date = (dateTime != null) ? dateTime.toLocalDate() : this.date;
+        this.time = (dateTime != null) ? dateTime.toLocalTime() : this.time;
         this.memo = (memo != null) ? memo : this.place;
     }
 

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -49,7 +49,7 @@ public class Meeting extends BaseTimeEntity {
         return meeting;
     }
 
-    public void updateTitleAndPlaceAndDateAndTimeAndMemo(String title, String place, LocalDateTime dateTime, String memo) {
+    public void updateMeetingInfo(String title, String place, LocalDateTime dateTime, String memo) {
         this.title = (title != null) ? title : this.title;
         this.place = (place != null) ? place : this.place;
         this.date = (dateTime != null) ? dateTime.toLocalDate() : this.date;

--- a/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/request/UpdateMeetingInfoRequestDto.java
@@ -3,8 +3,8 @@ package org.baggle.domain.meeting.dto.request;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.time.LocalDate;
-import java.time.LocalTime;
+
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -12,7 +12,6 @@ public class UpdateMeetingInfoRequestDto {
     private Long meetingId;
     private String title;
     private String place;
-    private LocalDate date;
-    private LocalTime time;
+    private LocalDateTime dateTime;
     private String memo;
 }

--- a/src/main/java/org/baggle/domain/meeting/dto/response/UpdateMeetingInfoResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/UpdateMeetingInfoResponseDto.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
@@ -13,19 +12,16 @@ public class UpdateMeetingInfoResponseDto {
     private Long meetingId;
     private String title;
     private String place;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private LocalDate date;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalTime time;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-ddTHH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime dateTime;
     private String memo;
 
-    public static UpdateMeetingInfoResponseDto of(Long meetingId, String title, String place, LocalDate date, LocalTime time, String memo) {
+    public static UpdateMeetingInfoResponseDto of(Long meetingId, String title, String place, LocalDateTime dateTime, String memo) {
         return UpdateMeetingInfoResponseDto.builder()
                 .meetingId(meetingId)
                 .title(title)
                 .place(place)
-                .date(date)
-                .time(time)
+                .dateTime(dateTime)
                 .memo(memo)
                 .build();
     }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -57,7 +57,7 @@ public class MeetingDetailService {
         validateMeetingHost(meeting.getId(), userId);
         validateMeetingStatus(meeting);
         validateMeetingDateTime(meeting, requestDto.getDateTime());
-        meeting.updateTitleAndPlaceAndDateAndTimeAndMemo(requestDto.getTitle(), requestDto.getPlace(), requestDto.getDateTime(), requestDto.getMemo());
+        meeting.updateMeetingInfo(requestDto.getTitle(), requestDto.getPlace(), requestDto.getDateTime(), requestDto.getMemo());
         return UpdateMeetingInfoResponseDto.of(meeting.getId(), meeting.getTitle(), meeting.getPlace(), LocalDateTime.of(meeting.getDate(), meeting.getTime()), meeting.getMemo());
     }
 

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -8,7 +8,6 @@ import org.baggle.domain.fcm.repository.FcmRepository;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
 import org.baggle.domain.fcm.service.FcmNotificationProvider;
 import org.baggle.domain.fcm.service.FcmNotificationService;
-import org.baggle.domain.fcm.service.FcmService;
 import org.baggle.domain.meeting.domain.*;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
@@ -57,9 +56,9 @@ public class MeetingDetailService {
         Meeting meeting = getMeeting(requestDto.getMeetingId());
         validateMeetingHost(meeting.getId(), userId);
         validateMeetingStatus(meeting);
-        validateMeetingDateTime(meeting, requestDto.getDate(), requestDto.getTime());
-        meeting.updateTitleAndPlaceAndDateAndTimeAndMemo(requestDto.getTitle(), requestDto.getPlace(), requestDto.getDate(), requestDto.getTime(), requestDto.getMemo());
-        return UpdateMeetingInfoResponseDto.of(meeting.getId(), meeting.getTitle(), meeting.getPlace(), meeting.getDate(), meeting.getTime(), meeting.getMemo());
+        validateMeetingDateTime(meeting, requestDto.getDateTime());
+        meeting.updateTitleAndPlaceAndDateAndTimeAndMemo(requestDto.getTitle(), requestDto.getPlace(), requestDto.getDateTime(), requestDto.getMemo());
+        return UpdateMeetingInfoResponseDto.of(meeting.getId(), meeting.getTitle(), meeting.getPlace(), LocalDateTime.of(meeting.getDate(), meeting.getTime()), meeting.getMemo());
     }
 
     public void deleteMeetingInfo(Long userId, Long meetingId) {
@@ -142,10 +141,10 @@ public class MeetingDetailService {
             throw new ForbiddenException(INVALID_MODIFY_TIME);
     }
 
-    private void validateMeetingDateTime(Meeting meeting, LocalDate requestDate, LocalTime requestTime) {
-        if (requestDate == null && requestTime == null) return;
-        LocalDate date = (requestDate == null) ? meeting.getDate() : requestDate;
-        LocalTime time = (requestTime == null) ? meeting.getTime() : requestTime;
+    private void validateMeetingDateTime(Meeting meeting, LocalDateTime requestDateTime) {
+        if (requestDateTime == null) return;
+        LocalDate date = requestDateTime.toLocalDate();
+        LocalTime time = requestDateTime.toLocalTime();
         validateModifyTimeWithRemainTime(meeting);
         validateMeetingTime(meeting, date, time);
     }


### PR DESCRIPTION
## Related Issue 🍃

close #135 

## Description 🌴
- 모임 정보 수정 api 응답에서 date & time 데이터를 합쳤습니다.
- 요청 받을 시 date & time 데이터를 합쳤습니다.
