### PR TITLE
[fix] 전체 모임 조회 정렬 오류 수정

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -56,9 +56,9 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "JOIN User u " +
             "ON p.user = u " +
             "WHERE u.id = :userId " +
-            "AND m.meetingStatus = :meetingStatus " +
-            "ORDER BY TIMEDIFF(:currTime, STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'))")
-    Page<Meeting> findMeetingsWithMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);
+            "AND m.meetingStatus != :meetingStatus " +
+            "ORDER BY DATEDIFF(m.date, CAST(STR_TO_DATE(:currDate, '%Y-%m-%d') AS DATE)), REPLACE(CAST(TIMEDIFF(STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'), STR_TO_DATE(CONCAT(:currDate, ' ', :currTime), '%Y-%m-%d %H:%i:%s')) AS STRING), ':', '')")
+    Page<Meeting> findMeetingsWithoutMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currDate") String currDate, @Param("currTime") String currTime, Pageable pageable);
 
     @Query("SELECT m " +
             "FROM Meeting m " +
@@ -67,7 +67,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "JOIN User u " +
             "ON p.user = u " +
             "WHERE u.id = :userId " +
-            "AND m.meetingStatus != :meetingStatus " +
-            "ORDER BY TIMEDIFF(STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s'), :currTime)")
-    Page<Meeting> findMeetingsWithoutMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currTime") LocalDateTime currTime, Pageable pageable);
+            "AND m.meetingStatus = :meetingStatus " +
+            "ORDER BY DATEDIFF(CAST(STR_TO_DATE(:currDate, '%Y-%m-%d') AS DATE), m.date), REPLACE(CAST(TIMEDIFF(STR_TO_DATE(CONCAT(:currDate, ' ', :currTime), '%Y-%m-%d %H:%i:%s'), STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s')) AS STRING), ':', '')")
+    Page<Meeting> findMeetingsWithMeetingStatus(@Param("userId") Long userId, @Param("meetingStatus") MeetingStatus meetingStatus, @Param("currDate") String currDate, @Param("currTime") String currTime, Pageable pageable);
 }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingService.java
@@ -93,10 +93,11 @@ public class MeetingService {
 
     private List<MeetingResponseDto> getMeetingsAccordingToPeriod(Long userId, Period period, Pageable pageable) {
         Page<Meeting> meetings;
+        LocalDateTime now = LocalDateTime.now();
         if (period == Period.SCHEDULED) {
-            meetings = meetingRepository.findMeetingsWithoutMeetingStatus(userId, MeetingStatus.PAST, LocalDateTime.now(), pageable);
+            meetings = meetingRepository.findMeetingsWithoutMeetingStatus(userId, MeetingStatus.PAST, convertToLocalDate(now).toString(), convertToLocalTime(now).toString(), pageable);
         } else {
-            meetings = meetingRepository.findMeetingsWithMeetingStatus(userId, MeetingStatus.PAST, LocalDateTime.now(), pageable);
+            meetings = meetingRepository.findMeetingsWithMeetingStatus(userId, MeetingStatus.PAST, convertToLocalDate(now).toString(), convertToLocalTime(now).toString(), pageable);
         }
         return meetings.stream()
                 .map(MeetingResponseDto::of)


### PR DESCRIPTION
## Related Issue 🍃
close #154 

## Description 🌴
- 현재 날짜와 예정된 모임 날짜의 차이가 timediff 함수의 최대값 제한을 넘은 경우, 정렬이 정확하게 이루어지지 않았던 문제를 해결하였습니다.
- 변경된 정렬 기준 -> datediff 함수로 현재 날짜와 예정된 모임 날짜의 차이를 계산 후 오름차순 정렬합니다. 만약 두 날짜의 차이가 같은 경우 동일한 날짜에 예정된 모임이므로 시간과 분을 기준으로 정밀하게 계산하기 위해 timediff 함수로 한 번 더 오름차순 정렬합니다.
- 변경된 정렬 기준을 적용하면 동일한 날짜에 예정된 모임들만 timediff 함수의 영향을 받으므로 기존에 문제가 되었던 최댓값 제한을 해결할 수 있었습니다.
