### PR TITLE
[fix] 모임 확정 알림시 빈 fcm token 오류 해결

### DIFF
--- a/src/main/java/org/baggle/domain/fcm/domain/FcmNotification.java
+++ b/src/main/java/org/baggle/domain/fcm/domain/FcmNotification.java
@@ -3,6 +3,7 @@ package org.baggle.domain.fcm.domain;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.baggle.domain.fcm.service.FcmService;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
@@ -14,4 +15,11 @@ public class FcmNotification {
     @Id
     private Long id;
     private Boolean isNotified;
+
+    public static FcmNotification createFcmNotification(Long key){
+        return FcmNotification.builder()
+                .id(key)
+                .isNotified(Boolean.TRUE)
+                .build();
+    }
 }

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -49,7 +49,7 @@ public class NotificationScheduler {
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting, ButtonAuthority buttonAuthority) {
         List<FcmToken> fcmTokens = findFcmTokensByButtonAuthority(meeting, buttonAuthority);
-        fcmTokens.forEach(fcmToken -> log.info("fcmList", fcmToken));
+        fcmTokens.forEach(fcmToken -> log.info("fcmList - {}", fcmToken));
         String title = getNotificationTitleWithButtonAuthority(buttonAuthority);
         String body = getNotificationBodyWithButtonAuthority(buttonAuthority);
         return FcmNotificationRequestDto.of(fcmTokens, title, body);

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -44,12 +44,11 @@ public class NotificationScheduler {
 
     private List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
         List<FcmToken> fcmTokenList = fcmNotificationService.findFcmTokensByButtonAuthority(meeting, buttonAuthority);
-        return fcmTokenList.stream().filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
+        return fcmTokenList.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).toList();
     }
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting, ButtonAuthority buttonAuthority) {
         List<FcmToken> fcmTokens = findFcmTokensByButtonAuthority(meeting, buttonAuthority);
-        fcmTokens.forEach(fcmToken -> log.info("fcmList - {}", fcmToken));
         String title = getNotificationTitleWithButtonAuthority(buttonAuthority);
         String body = getNotificationBodyWithButtonAuthority(buttonAuthority);
         return FcmNotificationRequestDto.of(fcmTokens, title, body);

--- a/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
+++ b/src/main/java/org/baggle/domain/fcm/scheduler/NotificationScheduler.java
@@ -10,6 +10,7 @@ import org.baggle.domain.fcm.service.FcmNotificationService;
 import org.baggle.domain.meeting.domain.ButtonAuthority;
 import org.baggle.domain.meeting.domain.Meeting;
 import org.baggle.domain.meeting.domain.MeetingStatus;
+import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.domain.meeting.service.MeetingDetailService;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -17,6 +18,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Component
@@ -27,6 +29,7 @@ public class NotificationScheduler {
     private final MeetingDetailService meetingDetailService;
     private final FcmNotificationService fcmNotificationService;
     private final FcmNotificationProvider fcmNotificationProvider;
+    private final ParticipationRepository participationRepository;
 
     @Transactional
     @Scheduled(cron = "0 * * * * *")
@@ -41,12 +44,13 @@ public class NotificationScheduler {
         }
     }
 
-    private List<FcmToken> getFcmTokens(Meeting meeting, ButtonAuthority buttonAuthority) {
-        return fcmNotificationService.findFcmTokensByButtonAuthority(meeting, buttonAuthority);
+    private List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
+        List<FcmToken> fcmTokenList = participationRepository.findFcmTokensByMeetingAndButtonAuthority(meeting, buttonAuthority);
+        return fcmTokenList.stream().filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
     }
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting, ButtonAuthority buttonAuthority) {
-        List<FcmToken> fcmTokens = getFcmTokens(meeting, buttonAuthority);
+        List<FcmToken> fcmTokens = findFcmTokensByButtonAuthority(meeting, buttonAuthority);
         String title = getNotificationTitleWithButtonAuthority(buttonAuthority);
         String body = getNotificationBodyWithButtonAuthority(buttonAuthority);
         return FcmNotificationRequestDto.of(fcmTokens, title, body);

--- a/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
@@ -4,7 +4,6 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.baggle.domain.fcm.domain.FcmNotification;
@@ -13,15 +12,11 @@ import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
 import org.baggle.domain.fcm.repository.FcmNotificationRepository;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
-import org.baggle.domain.meeting.domain.ButtonAuthority;
-import org.baggle.domain.meeting.domain.Meeting;
-import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.global.error.exception.ErrorCode;
 import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,7 +25,6 @@ public class FcmNotificationService {
     private final FirebaseMessaging firebaseMessaging;
     private final FcmNotificationRepository fcmNotificationRepository;
     private final FcmTimerRepository fcmTimerRepository;
-    private final ParticipationRepository participationRepository;
 
     public void createFcmNotification(Long key) {
         FcmNotification fcmNotification = FcmNotification.builder()
@@ -42,11 +36,6 @@ public class FcmNotificationService {
 
     public void deleteFcmNotification(Long key) {
         fcmNotificationRepository.deleteById(key);
-    }
-
-    @Transactional
-    public List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
-        return participationRepository.findFcmTokensByMeetingAndButtonAuthority(meeting, buttonAuthority);
     }
 
     public void sendNotificationByToken(FcmNotificationRequestDto fcmNotificationRequestDto, Long meetingId) {

--- a/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
@@ -12,11 +12,15 @@ import org.baggle.domain.fcm.domain.FcmToken;
 import org.baggle.domain.fcm.dto.request.FcmNotificationRequestDto;
 import org.baggle.domain.fcm.repository.FcmNotificationRepository;
 import org.baggle.domain.fcm.repository.FcmTimerRepository;
+import org.baggle.domain.meeting.domain.ButtonAuthority;
+import org.baggle.domain.meeting.domain.Meeting;
+import org.baggle.domain.meeting.repository.ParticipationRepository;
 import org.baggle.global.error.exception.ErrorCode;
 import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -25,6 +29,7 @@ public class FcmNotificationService {
     private final FirebaseMessaging firebaseMessaging;
     private final FcmNotificationRepository fcmNotificationRepository;
     private final FcmTimerRepository fcmTimerRepository;
+    private final ParticipationRepository participationRepository;
 
     public void createFcmNotification(Long key) {
         FcmNotification fcmNotification = FcmNotification.builder()
@@ -32,6 +37,10 @@ public class FcmNotificationService {
                 .isNotified(Boolean.TRUE)
                 .build();
         fcmNotificationRepository.save(fcmNotification);
+    }
+
+    public List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
+        return participationRepository.findFcmTokensByMeetingAndButtonAuthority(meeting, buttonAuthority);
     }
 
     public void deleteFcmNotification(Long key) {

--- a/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
+++ b/src/main/java/org/baggle/domain/fcm/service/FcmNotificationService.java
@@ -4,6 +4,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.baggle.domain.fcm.domain.FcmNotification;
@@ -32,13 +33,11 @@ public class FcmNotificationService {
     private final ParticipationRepository participationRepository;
 
     public void createFcmNotification(Long key) {
-        FcmNotification fcmNotification = FcmNotification.builder()
-                .id(key)
-                .isNotified(Boolean.TRUE)
-                .build();
+        FcmNotification fcmNotification = FcmNotification.createFcmNotification(key);
         fcmNotificationRepository.save(fcmNotification);
     }
 
+    @Transactional
     public List<FcmToken> findFcmTokensByButtonAuthority(Meeting meeting, ButtonAuthority buttonAuthority) {
         return participationRepository.findFcmTokensByMeetingAndButtonAuthority(meeting, buttonAuthority);
     }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -155,7 +155,7 @@ public class MeetingDetailService {
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting) {
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meeting.getId());
-        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
+        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).toList();
         String title = fcmNotificationProvider.getDeleteNotificationTitle();
         String body = fcmNotificationProvider.getDeleteNotificationBody(meeting.getTitle());
         return FcmNotificationRequestDto.of(fcmTokens, title, body);

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -21,10 +21,10 @@ import org.baggle.global.error.exception.InvalidValueException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.baggle.global.common.TimeConverter.convertToLocalDateTime;
@@ -155,6 +155,7 @@ public class MeetingDetailService {
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Meeting meeting) {
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meeting.getId());
+        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
         String title = fcmNotificationProvider.getDeleteNotificationTitle();
         String body = fcmNotificationProvider.getDeleteNotificationBody(meeting.getTitle());
         return FcmNotificationRequestDto.of(fcmTokens, title, body);

--- a/src/main/java/org/baggle/infra/redis/ExpirationListener.java
+++ b/src/main/java/org/baggle/infra/redis/ExpirationListener.java
@@ -53,8 +53,7 @@ public class ExpirationListener implements MessageListener {
 
     private List<FcmToken> getFcmTokens(Long meetingId) {
         List<FcmToken> fcmTokenList = fcmService.findFcmTokens(meetingId);
-        return fcmTokenList.stream()
-                .filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
+        return fcmTokenList.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).toList();
     }
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(String dataType, Long meetingId) {

--- a/src/main/java/org/baggle/infra/redis/ExpirationListener.java
+++ b/src/main/java/org/baggle/infra/redis/ExpirationListener.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -51,7 +52,9 @@ public class ExpirationListener implements MessageListener {
     }
 
     private List<FcmToken> getFcmTokens(Long meetingId) {
-        return fcmService.findFcmTokens(meetingId);
+        List<FcmToken> fcmTokenList = fcmService.findFcmTokens(meetingId);
+        return fcmTokenList.stream()
+                .filter(fcmToken -> !Objects.isNull(fcmToken)).toList();
     }
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(String dataType, Long meetingId) {


### PR DESCRIPTION
## Related Issue 🍃

close #156 

## Description 🌴
- 로그아웃으로 인해 사라지는 fcm token으로 인한 에러로 Transcation이 완료되지 않아 데이터베이스가 업데이트되지 않던 오류를 해결했습니다.
- 다수의 fcm token을 조회하는 경우 null 값을 확인하는 로직을 추가했습니다.
