### PR TITLE
[feat] JWT 재발급 401 예외 시 로그아웃 기능 추가

### DIFF
--- a/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
+++ b/src/main/java/org/baggle/domain/user/controller/AuthApiController.java
@@ -1,6 +1,7 @@
 package org.baggle.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.baggle.domain.user.dto.request.UserReissueRequestDto;
 import org.baggle.domain.user.dto.request.UserSignInRequestDto;
 import org.baggle.domain.user.dto.response.UserAuthResponseDto;
 import org.baggle.domain.user.service.AuthService;
@@ -39,9 +40,10 @@ public class AuthApiController {
                 .body(BaseResponse.of(SuccessCode.CREATED, userAuthResponseDto));
     }
 
-    @GetMapping("/reissue")
-    public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader("Authorization") final String refreshToken) {
-        final Token reissuedToken = authService.reissue(refreshToken);
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader("Authorization") final String refreshToken,
+                                                   @RequestBody final UserReissueRequestDto userReissueRequestDto) {
+        final Token reissuedToken = authService.reissue(refreshToken, userReissueRequestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.of(SuccessCode.OK, reissuedToken));
     }

--- a/src/main/java/org/baggle/domain/user/dto/request/UserReissueRequestDto.java
+++ b/src/main/java/org/baggle/domain/user/dto/request/UserReissueRequestDto.java
@@ -1,0 +1,11 @@
+package org.baggle.domain.user.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class UserReissueRequestDto {
+    private Long userId;
+}

--- a/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
+++ b/src/main/java/org/baggle/global/config/jwt/JwtProvider.java
@@ -2,7 +2,6 @@ package org.baggle.global.config.jwt;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
-import io.jsonwebtoken.security.SignatureException;
 import lombok.Getter;
 import org.baggle.global.error.exception.ErrorCode;
 import org.baggle.global.error.exception.UnauthorizedException;
@@ -32,7 +31,7 @@ public class JwtProvider {
             getJwtParser().parseClaimsJws(accessToken);
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(ErrorCode.EXPIRED_ACCESS_TOKEN);
-        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+        } catch (Exception e) {
             throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         }
     }
@@ -42,7 +41,7 @@ public class JwtProvider {
             getJwtParser().parseClaimsJws(refreshToken);
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(ErrorCode.EXPIRED_REFRESH_TOKEN);
-        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+        } catch (Exception e) {
             throw new UnauthorizedException(ErrorCode.INVALID_REFRESH_TOKEN_VALUE);
         }
     }


### PR DESCRIPTION
## Related Issue 🍃
close #149 

## Description 🌴
- JWT 재발급 API의 스펙을 변경하였습니다.
- 리프레쉬 토큰 검증 시 예외가 발생하면 내부적으로 로그아웃 처리되도록 기능을 추가하였습니다.
