### PR TITLE
[fix] 긴급소집 fcm 알람 오류 해결

### DIFF
--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -29,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.baggle.global.error.exception.ErrorCode.*;
@@ -102,6 +103,7 @@ public class FeedService {
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Participation participation, Long meetingId) {
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meetingId);
+        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).toList();
         deleteFcmTokenOfRequestParticipation(fcmTokens, participation);
         String title = fcmNotificationProvider.getEmergencyNotificationTitle();
         String body = fcmNotificationProvider.getEmergencyNotificationBody();


### PR DESCRIPTION
## Related Issue 🍃

close #161 

## Description 🌴
- fcm token이 null일 경우 처리하는 로직을 추가했습니다.
