### PR TITLE
[fix] 모임 생성 예외 처리 변경사항 적용

### DIFF
--- a/src/main/java/org/baggle/BaggleApplication.java
+++ b/src/main/java/org/baggle/BaggleApplication.java
@@ -20,8 +20,7 @@ public class BaggleApplication {
     }
 
     @PostConstruct
-    public void started(){
+    public void started() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
+++ b/src/main/java/org/baggle/domain/meeting/controller/MeetingApiController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.baggle.domain.meeting.dto.request.CreateMeetingRequestDto;
 import org.baggle.domain.meeting.dto.request.UpdateMeetingInfoRequestDto;
 import org.baggle.domain.meeting.dto.response.CreateMeetingResponseDto;
-import org.baggle.domain.meeting.dto.response.GetMeetingResponseDto;
+import org.baggle.domain.meeting.dto.response.GetMeetingsResponseDto;
 import org.baggle.domain.meeting.dto.response.MeetingDetailResponseDto;
 import org.baggle.domain.meeting.dto.response.UpdateMeetingInfoResponseDto;
 import org.baggle.domain.meeting.service.MeetingDetailService;
@@ -37,9 +37,9 @@ public class MeetingApiController {
     public ResponseEntity<BaseResponse<?>> getMeetings(@UserId final Long userId,
                                                        @RequestParam final String period,
                                                        final Pageable pageable) {
-        final GetMeetingResponseDto getMeetingResponseDto = meetingService.getMeetings(userId, period, pageable);
+        final GetMeetingsResponseDto getMeetingsResponseDto = meetingService.getMeetings(userId, period, pageable);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(BaseResponse.of(SuccessCode.OK, getMeetingResponseDto));
+                .body(BaseResponse.of(SuccessCode.OK, getMeetingsResponseDto));
     }
 
     @GetMapping("/detail")

--- a/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Meeting.java
@@ -11,6 +11,8 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.baggle.domain.meeting.domain.Participation.createParticipation;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -43,7 +45,7 @@ public class Meeting extends BaseTimeEntity {
                 .memo(memo)
                 .meetingStatus(MeetingStatus.SCHEDULED)
                 .build();
-        Participation participation = Participation.createParticipation();
+        Participation participation = createParticipation();
         participation.changeUser(user);
         participation.changeMeeting(meeting);
         return meeting;

--- a/src/main/java/org/baggle/domain/meeting/dto/response/GetMeetingsResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/GetMeetingsResponseDto.java
@@ -11,13 +11,13 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
-public class GetMeetingResponseDto {
+public class GetMeetingsResponseDto {
     private Long scheduledCount;
     private Long pastCount;
     private List<MeetingResponseDto> meetings;
 
-    public static GetMeetingResponseDto of(MeetingCountQueryDto meetingCountQueryDto, List<MeetingResponseDto> meetings) {
-        return GetMeetingResponseDto.builder()
+    public static GetMeetingsResponseDto of(MeetingCountQueryDto meetingCountQueryDto, List<MeetingResponseDto> meetings) {
+        return GetMeetingsResponseDto.builder()
                 .scheduledCount(meetingCountQueryDto.getScheduledCount() != null ? meetingCountQueryDto.getScheduledCount() : 0)
                 .pastCount(meetingCountQueryDto.getPastCount() != null ? meetingCountQueryDto.getPastCount() : 0)
                 .meetings(meetings)

--- a/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/org/baggle/domain/meeting/repository/MeetingRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -29,16 +28,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "WHERE STR_TO_DATE(CONCAT(m.date, ' ', m.time), '%Y-%m-%d %H:%i:%s') BETWEEN :from AND :to " +
             "AND u.id = :userId")
     List<Meeting> findMeetingsWithinTimeRange(@Param("userId") Long userId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
-
-    @Query("SELECT count(m) " +
-            "FROM Meeting m " +
-            "JOIN Participation p " +
-            "ON m = p.meeting " +
-            "JOIN User u " +
-            "ON p.user = u " +
-            "WHERE m.date = :date " +
-            "AND u.id = :userId")
-    Long countMeetingWithinDate(@Param("userId") Long userId, @Param("date") LocalDate date);
 
     @Query("SELECT new org.baggle.domain.meeting.repository.MeetingCountQueryDto(SUM(CASE WHEN m.meetingStatus != :meetingStatus THEN 1 END), SUM(CASE WHEN m.meetingStatus = :meetingStatus THEN 1 END)) " +
             "FROM Meeting m " +

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     INVALID_MEETING_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 모임 시간입니다."),
     INVALID_CERTIFICATION_TIME(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 시간입니다."),
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
-    UNAVAILABLE_MEETING_TIME(HttpStatus.BAD_REQUEST, "모임 2시간 전후 일정이 존재합니다."),
+    UNAVAILABLE_MEETING_TIME(HttpStatus.BAD_REQUEST, "모임 1시간 전후 일정이 존재합니다."),
     INVALID_PERIOD_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 기간 타입입니다."),
 
     /**
@@ -49,7 +49,6 @@ public enum ErrorCode {
     INVALID_MODIFY_TIME(HttpStatus.FORBIDDEN, "모임 정보 수정 가능한 시간이 아닙니다."),
     INVALID_MEETING_CAPACITY(HttpStatus.FORBIDDEN, "모임 인원이 초과됐습니다."),
     NOT_MATCH_BUTTON_OWNER(HttpStatus.FORBIDDEN, "긴급 버튼 할당자가 아닙니다."),
-    INVALID_CREATE_MEETING(HttpStatus.FORBIDDEN, "모임은 하루에 2개까지만 생성 가능합니다."),
 
     /**
      * 404 Not Found


### PR DESCRIPTION
## Related Issue 🍃
close #165 

## Description 🌴
- 모임 생성 예외 처리를 변경하였습니다.
- 1. 모임 날짜와 시각이 모임 생성 요청 날짜와 시각 + 1시간 이후인 경우에만 생성이 가능하도록 예외 처리하였습니다.
- 2. 모임 날짜와 시각 전후 1시간내에 다른 모임이 존재하는 경우 생성이 불가능하도록 예외 처리하였습니다.
