### PR TITLE
[fix] feed fcmToken 오류 로직 해결

### DIFF
--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.baggle.global.error.exception.ErrorCode.*;
 
@@ -103,7 +104,7 @@ public class FeedService {
 
     private FcmNotificationRequestDto createFcmNotificationRequestDto(Participation participation, Long meetingId) {
         List<FcmToken> fcmTokens = fcmRepository.findByUserParticipationsMeetingId(meetingId);
-        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).toList();
+        fcmTokens = fcmTokens.stream().filter(fcmToken -> !Objects.isNull(fcmToken.getFcmToken())).collect(Collectors.toList());
         deleteFcmTokenOfRequestParticipation(fcmTokens, participation);
         String title = fcmNotificationProvider.getEmergencyNotificationTitle();
         String body = fcmNotificationProvider.getEmergencyNotificationBody();

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -113,8 +113,6 @@ public class FeedService {
 
     private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation){
         FcmToken fcmToken = participation.getUser().getFcmToken();
-        System.out.println(fcmToken.getFcmToken());
-        fcmTokens.forEach(fcmToken1 -> System.out.println(fcmToken1.getFcmToken()));
         fcmTokens.remove(fcmToken);
     }
 

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -112,7 +112,7 @@ public class FeedService {
 
     private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation){
         FcmToken fcmToken = participation.getUser().getFcmToken();
-        System.out.println(Objects.isNull(fcmToken));
+        System.out.println(Objects.isNull(fcmTokens));
         fcmTokens.remove(fcmToken);
     }
 

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -112,7 +112,8 @@ public class FeedService {
 
     private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation){
         FcmToken fcmToken = participation.getUser().getFcmToken();
-        System.out.println(Objects.isNull(fcmTokens));
+        System.out.println(fcmToken.getFcmToken());
+        fcmTokens.forEach(fcmToken1 -> System.out.println(fcmToken1.getFcmToken()));
         fcmTokens.remove(fcmToken);
     }
 

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -112,6 +112,7 @@ public class FeedService {
 
     private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation){
         FcmToken fcmToken = participation.getUser().getFcmToken();
+        System.out.println(Objects.isNull(fcmToken));
         fcmTokens.remove(fcmToken);
     }
 


### PR DESCRIPTION
## Related Issue 🍃

close #167 

## Description 🌴
- feed fcm token에서 null exception 문제를 해결했습니다.
- stream으로 반환된 list를 add or remove가 가능한 자료형으로 바꾸었습니다.
