### PR TITLE
[feat] 신고 api 구현

### DIFF
--- a/src/main/java/org/baggle/domain/feed/domain/Feed.java
+++ b/src/main/java/org/baggle/domain/feed/domain/Feed.java
@@ -34,4 +34,8 @@ public class Feed extends BaseTimeEntity {
                 .feedImageUrl(feedImageUrl)
                 .build();
     }
+
+    public void addReport(Report report){
+        this.reports.add(report);
+    }
 }

--- a/src/main/java/org/baggle/domain/feed/domain/Feed.java
+++ b/src/main/java/org/baggle/domain/feed/domain/Feed.java
@@ -28,7 +28,7 @@ public class Feed extends BaseTimeEntity {
     @Builder.Default
     private List<Report> reports = new ArrayList<>();
 
-    public static Feed createParticipationWithFeedImg(Participation participation, String feedImageUrl) {
+    public static Feed createFeed(Participation participation, String feedImageUrl) {
         return Feed.builder()
                 .participation(participation)
                 .feedImageUrl(feedImageUrl)

--- a/src/main/java/org/baggle/domain/feed/domain/Feed.java
+++ b/src/main/java/org/baggle/domain/feed/domain/Feed.java
@@ -3,7 +3,11 @@ package org.baggle.domain.feed.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.baggle.domain.meeting.domain.Participation;
+import org.baggle.domain.report.domain.Report;
 import org.baggle.global.common.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -20,6 +24,9 @@ public class Feed extends BaseTimeEntity {
     private Participation participation;
     @Column(nullable = false)
     private String feedImageUrl;
+    @OneToMany(mappedBy = "feed")
+    @Builder.Default
+    private List<Report> reports = new ArrayList<>();
 
     public static Feed createParticipationWithFeedImg(Participation participation, String feedImageUrl) {
         return Feed.builder()

--- a/src/main/java/org/baggle/domain/feed/domain/Feed.java
+++ b/src/main/java/org/baggle/domain/feed/domain/Feed.java
@@ -35,7 +35,7 @@ public class Feed extends BaseTimeEntity {
                 .build();
     }
 
-    public void addReport(Report report){
+    public void addReport(Report report) {
         this.reports.add(report);
     }
 }

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -50,9 +50,9 @@ public class FeedService {
         Participation participation = getParticipation(requestDto.getMemberId());
         duplicationParticipation(participation);
         validateCertificationTime(participation.getMeeting());
-        String imgUrl = s3Provider.uploadFile(feedImage, ImageType.FEED.getImageType());
+        String imgUrl = uploadImageToS3(feedImage);
         Feed feed = Feed.createParticipationWithFeedImg(participation, imgUrl);
-        feedRepository.save(feed);
+        saveFeed(feed);
         return FeedUploadResponseDto.of(feed.getId(), feed.getFeedImageUrl());
     }
 
@@ -63,6 +63,14 @@ public class FeedService {
         broadcastNotification(participation, participation.getMeeting());
         startEmergencyNotificationEvent(participation, authorizationTime);
         return FeedNotificationResponseDto.of(participation.getMeeting(), authorizationTime);
+    }
+
+    private String uploadImageToS3(MultipartFile feedImage) {
+        return s3Provider.uploadFile(feedImage, ImageType.FEED.getImageType());
+    }
+
+    private void saveFeed(Feed feed) {
+        feedRepository.save(feed);
     }
 
     private Meeting getMeeting(Long meetingId) {
@@ -110,7 +118,7 @@ public class FeedService {
         return FcmNotificationRequestDto.of(fcmTokens, title, body);
     }
 
-    private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation){
+    private void deleteFcmTokenOfRequestParticipation(List<FcmToken> fcmTokens, Participation participation) {
         FcmToken fcmToken = participation.getUser().getFcmToken();
         fcmTokens.remove(fcmToken);
     }

--- a/src/main/java/org/baggle/domain/feed/service/FeedService.java
+++ b/src/main/java/org/baggle/domain/feed/service/FeedService.java
@@ -51,7 +51,7 @@ public class FeedService {
         duplicationParticipation(participation);
         validateCertificationTime(participation.getMeeting());
         String imgUrl = uploadImageToS3(feedImage);
-        Feed feed = Feed.createParticipationWithFeedImg(participation, imgUrl);
+        Feed feed = Feed.createFeed(participation, imgUrl);
         saveFeed(feed);
         return FeedUploadResponseDto.of(feed.getId(), feed.getFeedImageUrl());
     }

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -79,4 +79,8 @@ public class Participation extends BaseTimeEntity {
     public void updateMeetingAuthorityToParticipation() {
         this.meetingAuthority = MeetingAuthority.PARTICIPATION;
     }
+
+    public void addReport(Report report){
+        this.reports.add(report);
+    }
 }

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -3,8 +3,12 @@ package org.baggle.domain.meeting.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.baggle.domain.feed.domain.Feed;
+import org.baggle.domain.report.domain.Report;
 import org.baggle.domain.user.domain.User;
 import org.baggle.global.common.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -24,8 +28,9 @@ public class Participation extends BaseTimeEntity {
     private Meeting meeting;
     @OneToOne(mappedBy = "participation", fetch = FetchType.LAZY)
     private Feed feed;
-    @OneToOne(mappedBy = "participation", fetch = FetchType.LAZY)
-    private Report report;
+    @OneToMany(mappedBy = "participation", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<Report> reports = new ArrayList<>();
     @Enumerated(value = EnumType.STRING)
     private MeetingAuthority meetingAuthority;
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -28,7 +28,7 @@ public class Participation extends BaseTimeEntity {
     private Meeting meeting;
     @OneToOne(mappedBy = "participation", fetch = FetchType.LAZY)
     private Feed feed;
-    @OneToMany(mappedBy = "participation", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "participation")
     @Builder.Default
     private List<Report> reports = new ArrayList<>();
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/org/baggle/domain/meeting/domain/Participation.java
+++ b/src/main/java/org/baggle/domain/meeting/domain/Participation.java
@@ -80,7 +80,7 @@ public class Participation extends BaseTimeEntity {
         this.meetingAuthority = MeetingAuthority.PARTICIPATION;
     }
 
-    public void addReport(Report report){
+    public void addReport(Report report) {
         this.reports.add(report);
     }
 }

--- a/src/main/java/org/baggle/domain/report/controller/ReportApiController.java
+++ b/src/main/java/org/baggle/domain/report/controller/ReportApiController.java
@@ -1,0 +1,27 @@
+package org.baggle.domain.report.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.domain.report.dto.request.CreateReportRequestDto;
+import org.baggle.domain.report.service.ReportService;
+import org.baggle.global.common.BaseResponse;
+import org.baggle.global.common.SuccessCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/report")
+@Controller
+public class ReportApiController {
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<?>> createReport(@RequestBody CreateReportRequestDto requestDto){
+        reportService.createReport(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.of(SuccessCode.CREATED, null));
+    }
+}

--- a/src/main/java/org/baggle/domain/report/controller/ReportApiController.java
+++ b/src/main/java/org/baggle/domain/report/controller/ReportApiController.java
@@ -19,7 +19,7 @@ public class ReportApiController {
     private final ReportService reportService;
 
     @PostMapping
-    public ResponseEntity<BaseResponse<?>> createReport(@RequestBody CreateReportRequestDto requestDto){
+    public ResponseEntity<BaseResponse<?>> createReport(@RequestBody CreateReportRequestDto requestDto) {
         reportService.createReport(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.of(SuccessCode.CREATED, null));

--- a/src/main/java/org/baggle/domain/report/domain/Report.java
+++ b/src/main/java/org/baggle/domain/report/domain/Report.java
@@ -22,4 +22,17 @@ public class Report extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "participation_id")
     private Participation participation;
+    @Enumerated(value = EnumType.STRING)
+    private ReportType reportType;
+
+    public static Report createReport(Feed feed, Participation participation, ReportType reportType) {
+        Report createdReport = Report.builder()
+                .feed(feed)
+                .participation(participation)
+                .reportType(reportType)
+                .build();
+        feed.addReport(createdReport);
+        participation.addReport(createdReport);
+        return createdReport;
+    }
 }

--- a/src/main/java/org/baggle/domain/report/domain/Report.java
+++ b/src/main/java/org/baggle/domain/report/domain/Report.java
@@ -1,10 +1,14 @@
-package org.baggle.domain.meeting.domain;
+package org.baggle.domain.report.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import org.baggle.domain.feed.domain.Feed;
+import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.global.common.BaseTimeEntity;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Getter
 @Entity
 public class Report extends BaseTimeEntity {
@@ -12,10 +16,10 @@ public class Report extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
     private Long id;
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "participation_id")
-    private Participation participation;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "feed_id")
     private Feed feed;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id")
+    private Participation participation;
 }

--- a/src/main/java/org/baggle/domain/report/domain/ReportType.java
+++ b/src/main/java/org/baggle/domain/report/domain/ReportType.java
@@ -1,0 +1,25 @@
+package org.baggle.domain.report.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.baggle.global.error.exception.ErrorCode;
+import org.baggle.global.error.exception.InvalidValueException;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReportType {
+    SEXUALLY("sexually"),
+    VIOLENT("violent"),
+    UNPLEASANT("unpleasant");
+
+    private final String stringReportType;
+
+    public static ReportType getEnumReportTypeFromStringReportType(String stringReportType) {
+        return Arrays.stream(values())
+                .filter(reportType -> reportType.stringReportType.equals(stringReportType))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(ErrorCode.INVALID_REPORT_TYPE));
+    }
+}

--- a/src/main/java/org/baggle/domain/report/dto/request/CreateReportRequestDto.java
+++ b/src/main/java/org/baggle/domain/report/dto/request/CreateReportRequestDto.java
@@ -1,0 +1,13 @@
+package org.baggle.domain.report.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CreateReportRequestDto {
+    private Long participationId;
+    private Long feedId;
+    private String reportType;
+}

--- a/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package org.baggle.domain.report.repository;
+
+import org.baggle.domain.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/org/baggle/domain/report/service/ReportService.java
+++ b/src/main/java/org/baggle/domain/report/service/ReportService.java
@@ -1,0 +1,48 @@
+package org.baggle.domain.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.baggle.domain.feed.domain.Feed;
+import org.baggle.domain.feed.repository.FeedRepository;
+import org.baggle.domain.meeting.domain.Participation;
+import org.baggle.domain.meeting.repository.ParticipationRepository;
+import org.baggle.domain.report.domain.Report;
+import org.baggle.domain.report.domain.ReportType;
+import org.baggle.domain.report.dto.request.CreateReportRequestDto;
+import org.baggle.domain.report.repository.ReportRepository;
+import org.baggle.global.error.exception.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.baggle.global.error.exception.ErrorCode.FEED_NOT_FOUND;
+import static org.baggle.global.error.exception.ErrorCode.PARTICIPATION_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ReportService {
+    private final FeedRepository feedRepository;
+    private final ParticipationRepository participationRepository;
+    private final ReportRepository reportRepository;
+
+    public void createReport(CreateReportRequestDto requestDto) {
+        ReportType enumReportType = ReportType.getEnumReportTypeFromStringReportType(requestDto.getReportType());
+        Feed findFeed = getFeedWithId(requestDto.getFeedId());
+        Participation findParticipation = getParticipationWithId(requestDto.getParticipationId());
+        Report createdReport = Report.createReport(findFeed, findParticipation, enumReportType);
+        saveReport(createdReport);
+    }
+
+    private void saveReport(Report report) {
+        reportRepository.save(report);
+    }
+
+    private Feed getFeedWithId(Long feedId) {
+        return feedRepository.findById(feedId)
+                .orElseThrow(() -> new EntityNotFoundException(FEED_NOT_FOUND));
+    }
+
+    private Participation getParticipationWithId(Long participationId) {
+        return participationRepository.findById(participationId)
+                .orElseThrow(() -> new EntityNotFoundException(PARTICIPATION_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/baggle/domain/report/service/ReportService.java
+++ b/src/main/java/org/baggle/domain/report/service/ReportService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static org.baggle.global.error.exception.ErrorCode.FEED_NOT_FOUND;
 import static org.baggle.global.error.exception.ErrorCode.PARTICIPATION_NOT_FOUND;
+import static org.baggle.domain.report.domain.ReportType.getEnumReportTypeFromStringReportType;
 
 @RequiredArgsConstructor
 @Transactional
@@ -25,7 +26,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
 
     public void createReport(CreateReportRequestDto requestDto) {
-        ReportType enumReportType = ReportType.getEnumReportTypeFromStringReportType(requestDto.getReportType());
+        ReportType enumReportType = getEnumReportTypeFromStringReportType(requestDto.getReportType());
         Feed findFeed = getFeedWithId(requestDto.getFeedId());
         Participation findParticipation = getParticipationWithId(requestDto.getParticipationId());
         Report createdReport = Report.createReport(findFeed, findParticipation, enumReportType);

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_MEETING_PARTICIPATION(HttpStatus.BAD_REQUEST, "잘못된 모임 참가자 입니다."),
     UNAVAILABLE_MEETING_TIME(HttpStatus.BAD_REQUEST, "모임 1시간 전후 일정이 존재합니다."),
     INVALID_PERIOD_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 기간 타입입니다."),
+    INVALID_REPORT_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 신고 유형입니다."),
 
     /**
      * 401 Unauthorized
@@ -60,6 +61,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     MEETING_COUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "모임의 총개수를 확인할 수 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰을 찾을 수 없습니다."),
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/resources/db/migration/V5__add_report_type.sql
+++ b/src/main/resources/db/migration/V5__add_report_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE report ADD COLUMN report_type VARCHAR(255) CHECK (report_type IN ('SEXUALLY', 'VIOLENT', 'UNPLEASANT'));


### PR DESCRIPTION
## Related Issue 🍃

close #169 

## Description 🌴
- 피드 신고 api를 구현했습니다.
- 추가 유저신고 기능 확장을 위해 report domain package를 만들었습니다.
- 기존에 구성했던 report table에 새로운 report_type column을 추가했습니다.
- 존재하지 않는 feed, 존재하지 않는 참가자, 신고 유형이 잘 못된 경우 예외처리를 진행했습니다.
