### PR TITLE
[fix] 모임상세 api에 신고 내용 추가

### DIFF
--- a/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/MeetingDetailResponseDto.java
@@ -8,6 +8,7 @@ import org.baggle.domain.meeting.domain.Meeting;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
 @Getter
 public class MeetingDetailResponseDto {
     private Long meetingId;
@@ -21,19 +22,8 @@ public class MeetingDetailResponseDto {
     private LocalDateTime certificationTime;
     private List<ParticipationDetailResponseDto> members;
 
-    @Builder
-    public MeetingDetailResponseDto(Long meetingId, String title, String place, String memo, String status, LocalDateTime meetingTime, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> members) {
-        this.meetingId = meetingId;
-        this.title = title;
-        this.place = place;
-        this.memo = memo;
-        this.status = status;
-        this.meetingTime = meetingTime;
-        this.certificationTime = certificationTime;
-        this.members = members;
-    }
-
-    public static MeetingDetailResponseDto of(Meeting meeting, LocalDateTime meetingTime, LocalDateTime certificationTime, List<ParticipationDetailResponseDto> participationDetailResponseDto) {
+    public static MeetingDetailResponseDto of(Meeting meeting, LocalDateTime meetingTime, LocalDateTime certificationTime,
+                                              List<ParticipationDetailResponseDto> participationDetailResponseDto) {
         return MeetingDetailResponseDto.builder()
                 .meetingId(meeting.getId())
                 .title(meeting.getTitle())

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
@@ -8,7 +8,6 @@ import org.baggle.domain.meeting.domain.MeetingAuthority;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.user.domain.User;
 
-import java.util.List;
 import java.util.Objects;
 
 @Getter
@@ -20,36 +19,26 @@ public class ParticipationDetailResponseDto {
     private Boolean buttonAuthority;
     private Long feedId;
     private String feedImageUrl;
+    private boolean report;
 
     @Builder
-    public ParticipationDetailResponseDto(Long memberId, String nickname, String profileImageUrl, MeetingAuthority meetingAuthority, ButtonAuthority buttonAuthority, Feed feed) {
-        this.memberId = memberId;
-        this.nickname = nickname;
-        this.profileImageUrl = profileImageUrl;
-        this.meetingAuthority = (meetingAuthority == MeetingAuthority.HOST) ? Boolean.TRUE : Boolean.FALSE;
-        this.buttonAuthority = (buttonAuthority == ButtonAuthority.OWNER) ? Boolean.TRUE : Boolean.FALSE;
+    public ParticipationDetailResponseDto(User user, Participation participation, Feed feed, boolean report) {
+        this.memberId = participation.getId();
+        this.nickname = user.getNickname();
+        this.profileImageUrl = user.getProfileImageUrl();
+        this.meetingAuthority = (participation.getMeetingAuthority() == MeetingAuthority.HOST) ? Boolean.TRUE : Boolean.FALSE;
+        this.buttonAuthority = (participation.getButtonAuthority() == ButtonAuthority.OWNER) ? Boolean.TRUE : Boolean.FALSE;
         this.feedId = Objects.isNull(feed) ? null : feed.getId();
         this.feedImageUrl = Objects.isNull(feed) ? "" : feed.getFeedImageUrl();
+        this.report = report;
     }
 
-    public static ParticipationDetailResponseDto of(Participation participation, User user, Feed feed) {
+    public static ParticipationDetailResponseDto of(Participation participation, boolean report) {
         return ParticipationDetailResponseDto.builder()
-                .memberId(participation.getId())
-                .nickname(user.getNickname())
-                .profileImageUrl(user.getProfileImageUrl())
-                .meetingAuthority(participation.getMeetingAuthority())
-                .buttonAuthority(participation.getButtonAuthority())
-                .feed(feed)
+                .user(participation.getUser())
+                .participation(participation)
+                .feed(participation.getFeed())
+                .report(report)
                 .build();
-    }
-
-    public static List<ParticipationDetailResponseDto> listOf(List<Participation> participations) {
-        return participations.stream()
-                .map(participation ->
-                        ParticipationDetailResponseDto.of(
-                                participation,
-                                participation.getUser(),
-                                participation.getFeed()))
-                .toList();
     }
 }

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
@@ -8,6 +8,8 @@ import org.baggle.domain.meeting.domain.MeetingAuthority;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.user.domain.User;
 
+import java.util.Objects;
+
 @Builder
 @Getter
 public class ParticipationDetailResponseDto {
@@ -20,6 +22,18 @@ public class ParticipationDetailResponseDto {
     private String feedImageUrl;
     private boolean report;
 
+//    @Builder
+//    public ParticipationDetailResponseDto(User user, Participation participation, Feed feed, boolean report) {
+//        this.memberId = participation.getId();
+//        this.nickname = user.getNickname();
+//        this.profileImageUrl = user.getProfileImageUrl();
+//        this.meetingAuthority = (participation.getMeetingAuthority() == MeetingAuthority.HOST) ? Boolean.TRUE : Boolean.FALSE;
+//        this.buttonAuthority = (participation.getButtonAuthority() == ButtonAuthority.OWNER) ? Boolean.TRUE : Boolean.FALSE;
+//        this.feedId = Objects.isNull(feed) ? null : feed.getId();
+//        this.feedImageUrl = Objects.isNull(feed) ? "" : feed.getFeedImageUrl();
+//        this.report = report;
+//    }
+
     public static ParticipationDetailResponseDto of(Participation participation, boolean report) {
         User participationUser = participation.getUser();
         Feed participationFeed = participation.getFeed();
@@ -29,8 +43,8 @@ public class ParticipationDetailResponseDto {
                 .profileImageUrl(participationUser.getProfileImageUrl())
                 .meetingAuthority(participation.getMeetingAuthority() == MeetingAuthority.HOST)
                 .buttonAuthority(participation.getButtonAuthority() == ButtonAuthority.OWNER)
-                .feedId(participationFeed.getId())
-                .feedImageUrl(participationFeed.getFeedImageUrl())
+                .feedId(Objects.isNull(participationFeed) ? null : participationFeed.getId())
+                .feedImageUrl(Objects.isNull(participationFeed) ? "" : participationFeed.getFeedImageUrl())
                 .report(report)
                 .build();
     }

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
@@ -22,18 +22,6 @@ public class ParticipationDetailResponseDto {
     private String feedImageUrl;
     private boolean report;
 
-//    @Builder
-//    public ParticipationDetailResponseDto(User user, Participation participation, Feed feed, boolean report) {
-//        this.memberId = participation.getId();
-//        this.nickname = user.getNickname();
-//        this.profileImageUrl = user.getProfileImageUrl();
-//        this.meetingAuthority = (participation.getMeetingAuthority() == MeetingAuthority.HOST) ? Boolean.TRUE : Boolean.FALSE;
-//        this.buttonAuthority = (participation.getButtonAuthority() == ButtonAuthority.OWNER) ? Boolean.TRUE : Boolean.FALSE;
-//        this.feedId = Objects.isNull(feed) ? null : feed.getId();
-//        this.feedImageUrl = Objects.isNull(feed) ? "" : feed.getFeedImageUrl();
-//        this.report = report;
-//    }
-
     public static ParticipationDetailResponseDto of(Participation participation, boolean report) {
         User participationUser = participation.getUser();
         Feed participationFeed = participation.getFeed();

--- a/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
+++ b/src/main/java/org/baggle/domain/meeting/dto/response/ParticipationDetailResponseDto.java
@@ -8,36 +8,29 @@ import org.baggle.domain.meeting.domain.MeetingAuthority;
 import org.baggle.domain.meeting.domain.Participation;
 import org.baggle.domain.user.domain.User;
 
-import java.util.Objects;
-
+@Builder
 @Getter
 public class ParticipationDetailResponseDto {
     private Long memberId;
     private String nickname;
     private String profileImageUrl;
-    private Boolean meetingAuthority;
-    private Boolean buttonAuthority;
+    private boolean meetingAuthority;
+    private boolean buttonAuthority;
     private Long feedId;
     private String feedImageUrl;
     private boolean report;
 
-    @Builder
-    public ParticipationDetailResponseDto(User user, Participation participation, Feed feed, boolean report) {
-        this.memberId = participation.getId();
-        this.nickname = user.getNickname();
-        this.profileImageUrl = user.getProfileImageUrl();
-        this.meetingAuthority = (participation.getMeetingAuthority() == MeetingAuthority.HOST) ? Boolean.TRUE : Boolean.FALSE;
-        this.buttonAuthority = (participation.getButtonAuthority() == ButtonAuthority.OWNER) ? Boolean.TRUE : Boolean.FALSE;
-        this.feedId = Objects.isNull(feed) ? null : feed.getId();
-        this.feedImageUrl = Objects.isNull(feed) ? "" : feed.getFeedImageUrl();
-        this.report = report;
-    }
-
     public static ParticipationDetailResponseDto of(Participation participation, boolean report) {
+        User participationUser = participation.getUser();
+        Feed participationFeed = participation.getFeed();
         return ParticipationDetailResponseDto.builder()
-                .user(participation.getUser())
-                .participation(participation)
-                .feed(participation.getFeed())
+                .memberId(participation.getId())
+                .nickname(participationUser.getNickname())
+                .profileImageUrl(participationUser.getProfileImageUrl())
+                .meetingAuthority(participation.getMeetingAuthority() == MeetingAuthority.HOST)
+                .buttonAuthority(participation.getButtonAuthority() == ButtonAuthority.OWNER)
+                .feedId(participationFeed.getId())
+                .feedImageUrl(participationFeed.getFeedImageUrl())
                 .report(report)
                 .build();
     }

--- a/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/MeetingDetailService.java
@@ -82,7 +82,7 @@ public class MeetingDetailService {
     }
 
     private boolean isReportedFeed(List<Report> reportList, Feed feed) {
-        if(Objects.isNull(feed)) return false;
+        if (Objects.isNull(feed)) return false;
         return reportList.stream()
                 .anyMatch(report -> Objects.equals(report.getFeed().getId(), feed.getId()));
     }

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -33,22 +33,22 @@ public class ParticipationService {
 
     public ParticipationAvailabilityResponseDto findParticipationAvailability(Long userId, Long requestId) {
         Meeting meeting = getMeeting(requestId);
-//        validateMeetingStatus(meeting);
-//        validateMeetingTime(userId, meeting);
-//        duplicateParticipation(meeting.getParticipations(), userId);
-//        validateMeetingCapacity(meeting);
+        validateMeetingStatus(meeting);
+        validateMeetingTime(userId, meeting);
+        duplicateParticipation(meeting.getParticipations(), userId);
+        validateMeetingCapacity(meeting);
         return ParticipationAvailabilityResponseDto.of(meeting);
     }
 
     public void createParticipation(Long userId, ParticipationRequestDto requestDto) {
         Meeting meeting = getMeeting(requestDto.getMeetingId());
         User user = getUser(userId);
-//        duplicateParticipation(meeting.getParticipations(), userId);
-//        validateMeetingStatus(meeting);
-//        validateMeetingCapacity(meeting);
-//        validateMeetingTime(userId, meeting);
+        duplicateParticipation(meeting.getParticipations(), userId);
+        validateMeetingStatus(meeting);
+        validateMeetingCapacity(meeting);
+        validateMeetingTime(userId, meeting);
         Participation participation = createParticipationWithRandomButtonAuthority(user, meeting);
-        participationRepository.save(participation);
+        saveParticipation(participation);
     }
 
     public void delegateMeetingHost(Long fromMemberId, Long toMemberId) {
@@ -68,6 +68,10 @@ public class ParticipationService {
         validateMeetingStatus(meeting);
         withdrawBeforeMeetingConfirmation(participation, meeting);
         updateButtonAuthorityWithRandomNumber(meeting);
+    }
+
+    private void saveParticipation(Participation participation){
+        participationRepository.save(participation);
     }
 
     private Meeting getMeeting(Long meetingId) {

--- a/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
+++ b/src/main/java/org/baggle/domain/meeting/service/ParticipationService.java
@@ -62,7 +62,7 @@ public class ParticipationService {
         updateButtonAuthorityWithRandomNumber(meeting);
     }
 
-    public void withdrawMember(Long memberId){
+    public void withdrawMember(Long memberId) {
         Participation participation = getParticipation(memberId);
         Meeting meeting = getMeetingWithParticipation(participation);
         validateMeetingStatus(meeting);
@@ -70,7 +70,7 @@ public class ParticipationService {
         updateButtonAuthorityWithRandomNumber(meeting);
     }
 
-    private void saveParticipation(Participation participation){
+    private void saveParticipation(Participation participation) {
         participationRepository.save(participation);
     }
 

--- a/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
@@ -1,7 +1,9 @@
 package org.baggle.domain.report.repository;
 
 import org.baggle.domain.report.domain.Report;
+import org.baggle.domain.user.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsReportByFeedIdAndParticipationId(Long feedID, Long participationId);
 }

--- a/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
@@ -4,5 +4,5 @@ import org.baggle.domain.report.domain.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    boolean existsReportByFeedIdAndParticipationId(Long feedID, Long participationId);
+    boolean existsReportByFeedIdAndParticipationId(Long feedId, Long participationId);
 }

--- a/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
+++ b/src/main/java/org/baggle/domain/report/repository/ReportRepository.java
@@ -1,7 +1,6 @@
 package org.baggle.domain.report.repository;
 
 import org.baggle.domain.report.domain.Report;
-import org.baggle.domain.user.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {

--- a/src/main/java/org/baggle/domain/report/service/ReportService.java
+++ b/src/main/java/org/baggle/domain/report/service/ReportService.java
@@ -29,12 +29,12 @@ public class ReportService {
         ReportType enumReportType = getEnumReportTypeFromStringReportType(requestDto.getReportType());
         Feed findFeed = getFeedWithId(requestDto.getFeedId());
         Participation findParticipation = getParticipationWithId(requestDto.getParticipationId());
-        duplicateReport(findFeed, findParticipation);
+        validateDuplicateReport(findFeed, findParticipation);
         Report createdReport = Report.createReport(findFeed, findParticipation, enumReportType);
         saveReport(createdReport);
     }
 
-    private void duplicateReport(Feed feed, Participation participation) {
+    private void validateDuplicateReport(Feed feed, Participation participation) {
         if (reportRepository.existsReportByFeedIdAndParticipationId(feed.getId(), participation.getId()))
             throw new ConflictException(DUPLICATE_REPORT);
     }

--- a/src/main/java/org/baggle/domain/report/service/ReportService.java
+++ b/src/main/java/org/baggle/domain/report/service/ReportService.java
@@ -9,13 +9,14 @@ import org.baggle.domain.report.domain.Report;
 import org.baggle.domain.report.domain.ReportType;
 import org.baggle.domain.report.dto.request.CreateReportRequestDto;
 import org.baggle.domain.report.repository.ReportRepository;
+import org.baggle.global.error.exception.ConflictException;
 import org.baggle.global.error.exception.EntityNotFoundException;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.baggle.global.error.exception.ErrorCode.FEED_NOT_FOUND;
-import static org.baggle.global.error.exception.ErrorCode.PARTICIPATION_NOT_FOUND;
 import static org.baggle.domain.report.domain.ReportType.getEnumReportTypeFromStringReportType;
+import static org.baggle.global.error.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional
@@ -29,8 +30,14 @@ public class ReportService {
         ReportType enumReportType = getEnumReportTypeFromStringReportType(requestDto.getReportType());
         Feed findFeed = getFeedWithId(requestDto.getFeedId());
         Participation findParticipation = getParticipationWithId(requestDto.getParticipationId());
+        duplicateReport(findFeed, findParticipation);
         Report createdReport = Report.createReport(findFeed, findParticipation, enumReportType);
         saveReport(createdReport);
+    }
+
+    private void duplicateReport(Feed feed, Participation participation){
+        if(reportRepository.existsReportByFeedIdAndParticipationId(feed.getId(), participation.getId()))
+            throw new ConflictException(DUPLICATE_REPORT);
     }
 
     private void saveReport(Report report) {

--- a/src/main/java/org/baggle/domain/report/service/ReportService.java
+++ b/src/main/java/org/baggle/domain/report/service/ReportService.java
@@ -11,7 +11,6 @@ import org.baggle.domain.report.dto.request.CreateReportRequestDto;
 import org.baggle.domain.report.repository.ReportRepository;
 import org.baggle.global.error.exception.ConflictException;
 import org.baggle.global.error.exception.EntityNotFoundException;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,8 +34,8 @@ public class ReportService {
         saveReport(createdReport);
     }
 
-    private void duplicateReport(Feed feed, Participation participation){
-        if(reportRepository.existsReportByFeedIdAndParticipationId(feed.getId(), participation.getId()))
+    private void duplicateReport(Feed feed, Participation participation) {
+        if (reportRepository.existsReportByFeedIdAndParticipationId(feed.getId(), participation.getId()))
             throw new ConflictException(DUPLICATE_REPORT);
     }
 

--- a/src/main/java/org/baggle/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/baggle/global/error/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     DUPLICATE_PARTICIPATION(HttpStatus.CONFLICT, "이미 존재하는 참가자입니다."),
     DUPLICATE_FEED(HttpStatus.CONFLICT, "이미 피드인증을 완료했습니다."),
+    DUPLICATE_REPORT(HttpStatus.CONFLICT, "이미 등록된 신고입니다."),
 
     /**
      * 500 Internal Server Error


### PR DESCRIPTION
## Related Issue 🍃

close #179 

## Description 🌴
- 모임 상세 api에 신고 데이터를 추가했습니다.
- 피드를 올리지 않았을 경우 default 값으로 false를 전송합니다.
- 신고를 중복으로 할 수 있던 오류를 해결했습니다.
